### PR TITLE
feat: add global exception handling middleware

### DIFF
--- a/src/Scaffold.Api/Middleware/ExceptionHandlingMiddleware.cs
+++ b/src/Scaffold.Api/Middleware/ExceptionHandlingMiddleware.cs
@@ -1,0 +1,57 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Scaffold.Api.Middleware;
+
+public class ExceptionHandlingMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger<ExceptionHandlingMiddleware> _logger;
+
+    public ExceptionHandlingMiddleware(RequestDelegate next, ILogger<ExceptionHandlingMiddleware> logger)
+    {
+        _next = next;
+        _logger = logger;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        try
+        {
+            await _next(context);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unhandled exception occurred processing {Method} {Path}",
+                context.Request.Method, context.Request.Path);
+            await HandleExceptionAsync(context, ex);
+        }
+    }
+
+    private static async Task HandleExceptionAsync(HttpContext context, Exception exception)
+    {
+        // ArgumentNullException must be checked before ArgumentException since it inherits from it
+        var (statusCode, title) = exception switch
+        {
+            KeyNotFoundException => (StatusCodes.Status404NotFound, "Resource not found"),
+            ArgumentNullException => (StatusCodes.Status400BadRequest, "Invalid request"),
+            ArgumentException => (StatusCodes.Status400BadRequest, "Invalid request"),
+            InvalidOperationException => (StatusCodes.Status409Conflict, "Operation conflict"),
+            UnauthorizedAccessException => (StatusCodes.Status403Forbidden, "Forbidden"),
+            _ => (StatusCodes.Status500InternalServerError, "An unexpected error occurred")
+        };
+
+        var environment = context.RequestServices.GetRequiredService<IWebHostEnvironment>();
+
+        var problemDetails = new ProblemDetails
+        {
+            Status = statusCode,
+            Title = title,
+            Detail = environment.IsDevelopment() ? exception.Message : null,
+            Instance = context.Request.Path
+        };
+
+        context.Response.StatusCode = statusCode;
+        await context.Response.WriteAsJsonAsync(problemDetails, (JsonSerializerOptions?)null, "application/problem+json");
+    }
+}

--- a/src/Scaffold.Api/Program.cs
+++ b/src/Scaffold.Api/Program.cs
@@ -76,6 +76,7 @@ using (var scope = app.Services.CreateScope())
 
 // Configure the HTTP request pipeline.
 
+app.UseMiddleware<Scaffold.Api.Middleware.ExceptionHandlingMiddleware>();
 app.UseHttpsRedirection();
 app.UseCors("FrontendOrigin");
 app.UseAuthentication();

--- a/tests/Scaffold.Api.Tests/ExceptionHandlingMiddlewareTests.cs
+++ b/tests/Scaffold.Api.Tests/ExceptionHandlingMiddlewareTests.cs
@@ -1,0 +1,256 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Logging;
+using Scaffold.Api.Middleware;
+
+namespace Scaffold.Api.Tests;
+
+public class ExceptionHandlingMiddlewareTests
+{
+    private static ExceptionHandlingMiddleware CreateMiddleware(RequestDelegate next)
+    {
+        var logger = new LoggerFactory().CreateLogger<ExceptionHandlingMiddleware>();
+        return new ExceptionHandlingMiddleware(next, logger);
+    }
+
+    private static DefaultHttpContext CreateHttpContext(bool isDevelopment = false)
+    {
+        var context = new DefaultHttpContext();
+        context.Response.Body = new MemoryStream();
+        context.Request.Method = "GET";
+        context.Request.Path = "/api/test";
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IWebHostEnvironment>(new TestWebHostEnvironment(isDevelopment));
+        context.RequestServices = services.BuildServiceProvider();
+
+        return context;
+    }
+
+    private static async Task<ProblemDetails?> ReadProblemDetails(HttpResponse response)
+    {
+        response.Body.Seek(0, SeekOrigin.Begin);
+        return await JsonSerializer.DeserializeAsync<ProblemDetails>(response.Body, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+    }
+
+    [Fact]
+    public async Task InvokeAsync_NoException_PassesThrough()
+    {
+        // Arrange
+        var middleware = CreateMiddleware(_ => Task.CompletedTask);
+        var context = CreateHttpContext();
+
+        // Act
+        await middleware.InvokeAsync(context);
+
+        // Assert — response should not be modified by the middleware
+        Assert.Equal(200, context.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_KeyNotFoundException_Returns404()
+    {
+        // Arrange
+        var middleware = CreateMiddleware(_ => throw new KeyNotFoundException("Item not found"));
+        var context = CreateHttpContext(isDevelopment: true);
+
+        // Act
+        await middleware.InvokeAsync(context);
+        var problem = await ReadProblemDetails(context.Response);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
+        Assert.NotNull(problem);
+        Assert.Equal(404, problem.Status);
+        Assert.Equal("Resource not found", problem.Title);
+        Assert.Equal("Item not found", problem.Detail);
+        Assert.Equal("/api/test", problem.Instance);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ArgumentException_Returns400()
+    {
+        // Arrange
+        var middleware = CreateMiddleware(_ => throw new ArgumentException("Bad argument"));
+        var context = CreateHttpContext(isDevelopment: true);
+
+        // Act
+        await middleware.InvokeAsync(context);
+        var problem = await ReadProblemDetails(context.Response);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, context.Response.StatusCode);
+        Assert.NotNull(problem);
+        Assert.Equal(400, problem.Status);
+        Assert.Equal("Invalid request", problem.Title);
+        Assert.Equal("Bad argument", problem.Detail);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ArgumentNullException_Returns400()
+    {
+        // Arrange
+        var middleware = CreateMiddleware(_ => throw new ArgumentNullException("param", "Param is required"));
+        var context = CreateHttpContext(isDevelopment: true);
+
+        // Act
+        await middleware.InvokeAsync(context);
+        var problem = await ReadProblemDetails(context.Response);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, context.Response.StatusCode);
+        Assert.NotNull(problem);
+        Assert.Equal(400, problem.Status);
+        Assert.Equal("Invalid request", problem.Title);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_InvalidOperationException_Returns409()
+    {
+        // Arrange
+        var middleware = CreateMiddleware(_ => throw new InvalidOperationException("Conflict occurred"));
+        var context = CreateHttpContext(isDevelopment: true);
+
+        // Act
+        await middleware.InvokeAsync(context);
+        var problem = await ReadProblemDetails(context.Response);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status409Conflict, context.Response.StatusCode);
+        Assert.NotNull(problem);
+        Assert.Equal(409, problem.Status);
+        Assert.Equal("Operation conflict", problem.Title);
+        Assert.Equal("Conflict occurred", problem.Detail);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_UnauthorizedAccessException_Returns403()
+    {
+        // Arrange
+        var middleware = CreateMiddleware(_ => throw new UnauthorizedAccessException("Not allowed"));
+        var context = CreateHttpContext(isDevelopment: true);
+
+        // Act
+        await middleware.InvokeAsync(context);
+        var problem = await ReadProblemDetails(context.Response);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status403Forbidden, context.Response.StatusCode);
+        Assert.NotNull(problem);
+        Assert.Equal(403, problem.Status);
+        Assert.Equal("Forbidden", problem.Title);
+        Assert.Equal("Not allowed", problem.Detail);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_UnhandledException_Returns500()
+    {
+        // Arrange
+        var middleware = CreateMiddleware(_ => throw new NullReferenceException("Something broke"));
+        var context = CreateHttpContext(isDevelopment: true);
+
+        // Act
+        await middleware.InvokeAsync(context);
+        var problem = await ReadProblemDetails(context.Response);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status500InternalServerError, context.Response.StatusCode);
+        Assert.NotNull(problem);
+        Assert.Equal(500, problem.Status);
+        Assert.Equal("An unexpected error occurred", problem.Title);
+        Assert.Equal("Something broke", problem.Detail);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_Exception_ResponseContentType_IsProblemJson()
+    {
+        // Arrange
+        var middleware = CreateMiddleware(_ => throw new Exception("Error"));
+        var context = CreateHttpContext();
+
+        // Act
+        await middleware.InvokeAsync(context);
+
+        // Assert
+        Assert.StartsWith("application/problem+json", context.Response.ContentType);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ProductionEnvironment_DoesNotExposeExceptionDetails()
+    {
+        // Arrange — isDevelopment: false simulates Production
+        var middleware = CreateMiddleware(_ => throw new KeyNotFoundException("Sensitive info about DB"));
+        var context = CreateHttpContext(isDevelopment: false);
+
+        // Act
+        await middleware.InvokeAsync(context);
+        var problem = await ReadProblemDetails(context.Response);
+
+        // Assert
+        Assert.NotNull(problem);
+        Assert.Equal(404, problem.Status);
+        Assert.Null(problem.Detail); // No exception details in Production
+    }
+
+    [Fact]
+    public async Task InvokeAsync_DevelopmentEnvironment_IncludesExceptionDetails()
+    {
+        // Arrange
+        var middleware = CreateMiddleware(_ => throw new KeyNotFoundException("Detailed error info"));
+        var context = CreateHttpContext(isDevelopment: true);
+
+        // Act
+        await middleware.InvokeAsync(context);
+        var problem = await ReadProblemDetails(context.Response);
+
+        // Assert
+        Assert.NotNull(problem);
+        Assert.Equal("Detailed error info", problem.Detail);
+    }
+
+    [Theory]
+    [InlineData(typeof(KeyNotFoundException), 404)]
+    [InlineData(typeof(ArgumentException), 400)]
+    [InlineData(typeof(ArgumentNullException), 400)]
+    [InlineData(typeof(InvalidOperationException), 409)]
+    [InlineData(typeof(UnauthorizedAccessException), 403)]
+    [InlineData(typeof(NullReferenceException), 500)]
+    public async Task InvokeAsync_ExceptionMapping_ReturnsCorrectStatusCode(Type exceptionType, int expectedStatusCode)
+    {
+        // Arrange
+        var exception = (Exception)Activator.CreateInstance(exceptionType, "test message")!;
+        var middleware = CreateMiddleware(_ => throw exception);
+        var context = CreateHttpContext();
+
+        // Act
+        await middleware.InvokeAsync(context);
+
+        // Assert
+        Assert.Equal(expectedStatusCode, context.Response.StatusCode);
+    }
+
+    /// <summary>
+    /// Minimal IWebHostEnvironment stub for unit testing the middleware.
+    /// </summary>
+    private sealed class TestWebHostEnvironment : IWebHostEnvironment
+    {
+        public TestWebHostEnvironment(bool isDevelopment = false)
+        {
+            EnvironmentName = isDevelopment ? "Development" : "Production";
+        }
+
+        public string EnvironmentName { get; set; }
+        public string ApplicationName { get; set; } = "Scaffold.Api.Tests";
+        public string WebRootPath { get; set; } = string.Empty;
+        public IFileProvider WebRootFileProvider { get; set; } = new NullFileProvider();
+        public string ContentRootPath { get; set; } = string.Empty;
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+    }
+}


### PR DESCRIPTION
## Summary

Add a global exception handling middleware that catches unhandled exceptions and returns standardized RFC 7807 ProblemDetails JSON responses.

## Changes

### New Files
- **\src/Scaffold.Api/Middleware/ExceptionHandlingMiddleware.cs\** — Middleware that wraps the request pipeline in a try/catch and maps exceptions to appropriate HTTP status codes with ProblemDetails responses.
- **\	ests/Scaffold.Api.Tests/ExceptionHandlingMiddlewareTests.cs\** — 16 unit tests covering all exception mappings, content type, and environment-specific behavior.

### Modified Files
- **\src/Scaffold.Api/Program.cs\** — Register the middleware in the HTTP request pipeline (1 line added).

## Exception Mappings

| Exception Type | HTTP Status | Title |
|---|---|---|
| \KeyNotFoundException\ | 404 Not Found | Resource not found |
| \ArgumentNullException\ | 400 Bad Request | Invalid request |
| \ArgumentException\ | 400 Bad Request | Invalid request |
| \InvalidOperationException\ | 409 Conflict | Operation conflict |
| \UnauthorizedAccessException\ | 403 Forbidden | Forbidden |
| All others | 500 Internal Server Error | An unexpected error occurred |

## Behavior
- In **Development**, exception messages are included in the \detail\ field of ProblemDetails
- In **Production**, the \detail\ field is null (no stack traces or sensitive info leaked)
- All exceptions are logged via \ILogger\
- Response Content-Type is \pplication/problem+json\

## Tests
16 unit tests covering:
- Pass-through behavior (no exception -> 200)
- Each exception type mapping (6 specific + 1 parameterized Theory)
- Content-Type assertion
- Development vs Production detail exposure

Closes #8