### PR TITLE
feat: add request validation with DataAnnotations to API DTOs

### DIFF
--- a/src/Scaffold.Api/Controllers/AssessmentController.cs
+++ b/src/Scaffold.Api/Controllers/AssessmentController.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Scaffold.Assessment.SqlServer;
@@ -221,13 +222,13 @@ public class AssessmentController : ControllerBase
 }
 
 public record AssessmentRequest(
-    string? Server,
-    string? Database,
-    int? Port,
+    [StringLength(500)] string? Server,
+    [StringLength(200)] string? Database,
+    [Range(1, 65535)] int? Port,
     bool? UseSqlAuthentication,
-    string? Username,
+    [StringLength(200)] string? Username,
     string? Password,
     bool? TrustServerCertificate,
-    string? TargetService);
+    [StringLength(200)] string? TargetService);
 
-public record EvaluateTargetRequest(string TargetService);
+public record EvaluateTargetRequest([Required][StringLength(200)] string TargetService);

--- a/src/Scaffold.Api/Controllers/ConnectionController.cs
+++ b/src/Scaffold.Api/Controllers/ConnectionController.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Scaffold.Core.Interfaces;
@@ -37,11 +38,11 @@ public class ConnectionController : ControllerBase
 }
 
 public record ConnectionTestRequest(
-    string Server,
-    string Database,
-    int Port = 1433,
+    [Required][StringLength(500)] string Server,
+    [Required][StringLength(200)] string Database,
+    [Range(1, 65535)] int Port = 1433,
     bool UseSqlAuthentication = false,
-    string? Username = null,
+    [StringLength(200)] string? Username = null,
     string? Password = null,
-    string? KeyVaultSecretUri = null,
+    [StringLength(500)] string? KeyVaultSecretUri = null,
     bool TrustServerCertificate = false);

--- a/src/Scaffold.Api/Controllers/ProjectController.cs
+++ b/src/Scaffold.Api/Controllers/ProjectController.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Scaffold.Core.Interfaces;
@@ -87,5 +88,10 @@ public class ProjectController : ControllerBase
     }
 }
 
-public record CreateProjectRequest(string Name, string? Description, Core.Models.ConnectionInfo? ConnectionInfo);
-public record UpdateProjectRequest(string? Name, string? Description);
+public record CreateProjectRequest(
+    [Required][StringLength(200, MinimumLength = 1)] string Name,
+    [StringLength(2000)] string? Description,
+    Core.Models.ConnectionInfo? ConnectionInfo);
+public record UpdateProjectRequest(
+    [StringLength(200)] string? Name,
+    [StringLength(2000)] string? Description);

--- a/src/Scaffold.Api/Dtos/MigrationPlanDtos.cs
+++ b/src/Scaffold.Api/Dtos/MigrationPlanDtos.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using Scaffold.Core.Enums;
 using Scaffold.Core.Models;
 
@@ -13,7 +14,7 @@ public record MigrationScriptDto(
     int Order = 0);
 
 public record CreateMigrationPlanRequest(
-    MigrationStrategy Strategy,
+    [Required] MigrationStrategy Strategy,
     List<string>? IncludedObjects = null,
     List<string>? ExcludedObjects = null,
     DateTime? ScheduledAt = null,
@@ -23,7 +24,7 @@ public record CreateMigrationPlanRequest(
     List<MigrationScriptDto>? PostMigrationScripts = null,
     TierOverrideDto? TargetTierOverride = null,
     bool UseExistingTarget = false,
-    string? ExistingTargetConnectionString = null);
+    [StringLength(1000)] string? ExistingTargetConnectionString = null);
 
 public record UpdateMigrationPlanRequest(
     MigrationStrategy? Strategy = null,
@@ -36,16 +37,16 @@ public record UpdateMigrationPlanRequest(
     List<MigrationScriptDto>? PostMigrationScripts = null,
     TierOverrideDto? TargetTierOverride = null,
     bool? UseExistingTarget = null,
-    string? ExistingTargetConnectionString = null);
+    [StringLength(1000)] string? ExistingTargetConnectionString = null);
 
 public record TierOverrideDto(
-    string ServiceTier,
-    string ComputeSize,
+    [Required][StringLength(100)] string ServiceTier,
+    [Required][StringLength(100)] string ComputeSize,
     int? Dtus = null,
     int? VCores = null,
-    int StorageGb = 0,
-    decimal EstimatedMonthlyCostUsd = 0,
-    string? Reasoning = null);
+    [Range(0, 100000)] int StorageGb = 0,
+    [Range(0, 1000000)] decimal EstimatedMonthlyCostUsd = 0,
+    [StringLength(2000)] string? Reasoning = null);
 
 public record MigrationPlanResponse(
     Guid Id,
@@ -97,7 +98,7 @@ public record MigrationPlanResponse(
 #pragma warning restore CS0618
 }
 
-public record RejectMigrationPlanRequest(string? Reason = null);
+public record RejectMigrationPlanRequest([StringLength(2000)] string? Reason = null);
 
 public record MigrationPlanSummaryResponse(
     Guid PlanId,

--- a/tests/Scaffold.Api.Tests/RequestValidationTests.cs
+++ b/tests/Scaffold.Api.Tests/RequestValidationTests.cs
@@ -1,0 +1,57 @@
+using System.Net;
+using System.Net.Http.Json;
+using Scaffold.Api.Tests.Infrastructure;
+
+namespace Scaffold.Api.Tests;
+
+public class RequestValidationTests : IClassFixture<CustomWebApplicationFactory>
+{
+    private readonly HttpClient _client;
+
+    public RequestValidationTests(CustomWebApplicationFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task CreateProject_EmptyName_Returns400()
+    {
+        var response = await _client.PostAsJsonAsync("/api/projects",
+            new { Name = "", Description = "test" });
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreateProject_NameTooLong_Returns400()
+    {
+        var response = await _client.PostAsJsonAsync("/api/projects",
+            new { Name = new string('x', 201), Description = "test" });
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreateProject_ValidName_Returns201()
+    {
+        var response = await _client.PostAsJsonAsync("/api/projects",
+            new { Name = "Test Project", Description = "test" });
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task TestConnection_MissingServer_Returns400()
+    {
+        var response = await _client.PostAsJsonAsync("/api/connections/test",
+            new { Server = "", Database = "testdb" });
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(99999)]
+    public async Task TestConnection_InvalidPort_Returns400(int port)
+    {
+        var response = await _client.PostAsJsonAsync("/api/connections/test",
+            new { Server = "localhost", Database = "testdb", Port = port });
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+}


### PR DESCRIPTION
## Summary

Add request validation using \System.ComponentModel.DataAnnotations\ to all API request DTOs. The ASP.NET Core \[ApiController]\ attribute already enables automatic model validation, so adding proper annotations to the existing request records is sufficient.

## Changes

### Request DTOs updated with validation attributes:
- **CreateProjectRequest**: \[Required]\ name with \[StringLength(200, MinimumLength = 1)]\
- **UpdateProjectRequest**: \[StringLength]\ constraints on optional fields
- **ConnectionTestRequest**: \[Required]\ server/database, \[Range(1, 65535)]\ on port
- **AssessmentRequest**: \[StringLength]\ constraints on optional fields, \[Range]\ on port
- **EvaluateTargetRequest**: \[Required]\ target service with \[StringLength(200)]\
- **CreateMigrationPlanRequest**: \[Required]\ strategy, \[StringLength(1000)]\ on connection string
- **TierOverrideDto**: \[Required]\ tier/compute, \[Range]\ on storage/cost, \[StringLength]\ on reasoning
- **RejectMigrationPlanRequest**: \[StringLength(2000)]\ on reason

### New integration tests (6 tests):
- Empty project name -> 400 Bad Request
- Project name exceeding 200 chars -> 400 Bad Request
- Valid project name -> 201 Created (behavior preserved)
- Missing connection server -> 400 Bad Request
- Invalid port (0, 99999) -> 400 Bad Request

## Testing
- All 6 new validation tests pass
- All existing tests pass (no regressions)
- Build succeeds with no new warnings

Closes #9