### PR TITLE
Phase 3: PostgreSQL → Azure PostgreSQL Migration

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -58,6 +58,7 @@ For multi-step tasks, automatically invoke the matching workflow skill:
 | Research or technical investigation | `/spike-workflow` |
 | Preparing a release | `/release-workflow` |
 | Rolling back a failed deployment | `/rollback-workflow` |
+| Executing a multi-issue milestone | `/milestone-workflow` |
 | Filling in CUSTOMIZE placeholders after install | `/setup-teamwork` |
 
 ## Key Rules

--- a/.github/skills/milestone-workflow/SKILL.md
+++ b/.github/skills/milestone-workflow/SKILL.md
@@ -1,0 +1,238 @@
+---
+name: milestone-workflow
+description: "End-to-end workflow for delivering a multi-issue milestone from planning to merged, documented code. Use when executing a milestone (phase) containing multiple related issues that ship as a single PR."
+---
+
+# Milestone Development Workflow
+
+## Overview
+
+End-to-end workflow for delivering an entire milestone (phase) from architect review to
+merged code. Use this workflow when executing a group of related issues that belong to the
+same milestone and ship together as a single PR. This is the standard workflow for phased
+delivery — it extends the feature-workflow with wave-based implementation, parallel review
+pipelines, and milestone lifecycle management.
+
+For single-feature work that doesn't belong to a multi-issue milestone, use the
+`/feature-workflow` instead.
+
+## Trigger
+
+A human requests work on a specific milestone (e.g., "Begin on Phase 3"). The milestone
+must already exist in GitHub with issues assigned to it.
+
+## Steps
+
+| # | Role | Action | Inputs | Outputs | Success Criteria |
+|---|------|--------|--------|---------|------------------|
+| 0 | **Orchestrator** | Initialize workflow: create state file, validate milestone exists, list issues | Milestone name/number | `.teamwork/state/<id>.yaml`, issue inventory | State file created with status `active`; all issues listed |
+| 1 | **Architect** | Review all milestone issues for completeness, feasibility, dependencies; produce wave plan | Issue list, existing codebase | Feasibility assessment per issue, dependency graph, wave plan, ADR (if needed) | Every issue has sufficient acceptance criteria; waves form a valid DAG |
+| 2 | **Orchestrator** | Create branch `milestone/<phase-name>`, open Draft PR, link all issues | Wave plan, milestone metadata | Branch, Draft PR with issue checklist | PR created and linked to milestone |
+| 3 | **Coder** | Implement issues in wave order; link each issue to PR when work begins; commit per wave | Wave plan, design decisions, conventions | Commits on milestone branch, issues linked to PR | Each wave's code compiles and tests pass locally before next wave |
+| 4 | **Tester** | Review test coverage, write edge-case tests, validate against acceptance criteria per wave | PR branch, acceptance criteria | Additional tests, coverage assessment, defect reports | Acceptance criteria verified; edge cases covered; coverage meets thresholds |
+| 5 | **Orchestrator** | Run local test suite, verify all issues implemented, mark PR ready for review | PR with all waves complete | PR marked "Ready for Review", test results | All tests pass locally (`dotnet test` + `npx tsc --noEmit`) |
+| 6 | **Review Pipeline** | Run code-review + dba-agent + security-auditor agents **in parallel** on the PR | PR diff | Three review reports with findings (severity, location, remediation) | All three reviews complete |
+| 7 | **Architect** | Triage all findings into Fix Now / Follow-up / Tech Debt categories | Three review reports | Triage table with categorized findings and batched fix instructions | Every finding categorized; Fix Now items have clear instructions |
+| 8 | **Coder** | Fix all "Fix Now" items **sequentially** (one coder agent per batch) | Triage table, fix instructions | Commits addressing findings | All Fix Now items resolved; tests pass |
+| 9 | **Review Pipeline (Round 2)** | Re-run code-review + dba-agent + security-auditor on the fixes | Updated PR diff | Second review reports | No new high/critical findings introduced by fixes |
+| 10 | **Architect** | Triage Round 2 findings; if new Fix Now items exist, loop to step 8 (max 3 rounds) | Round 2 review reports | Updated triage table or "all clear" | No unresolved Fix Now items |
+| 11 | **Orchestrator** | Verify all CI checks green, all review findings addressed | CI status, triage results | CI verification report | All CI checks pass; no unresolved high/critical findings |
+| 12 | **Human** | Approves and merges the PR | Approved PR, CI green, review summary | Merged code on main branch | Code merged; CI passes on main |
+| 13 | **Documenter** | Update MEMORY.md with lessons learned, update CHANGELOG, close milestone issues | Merged PR, implementation notes | Updated docs, closed issues, closed milestone | All issues closed; milestone closed; MEMORY.md updated |
+| 14 | **Orchestrator** | Complete workflow: update state file, log metrics, create follow-up issues for deferred items | All step outputs, deferred items list | State file `completed`, follow-up issues created | Workflow finalized; no loose ends |
+
+## Handoff Contracts
+
+Each step must produce specific artifacts before the next step can begin.
+Handoffs are stored in `.teamwork/handoffs/<workflow-id>/`.
+
+**Human → Orchestrator (Step 0)**
+- Milestone name or number
+- Any special instructions or constraints
+
+**Orchestrator → Architect (Step 1)**
+- Issue inventory with titles, bodies, and current labels
+- Existing codebase context relevant to the milestone
+
+**Architect → Orchestrator (Step 2)**
+- Feasibility assessment per issue (comments on issues if needed)
+- Wave plan: ordered groups of issues with dependencies
+- Design decisions and conventions to follow
+- ADR file (if the milestone introduces new patterns)
+
+**Orchestrator → Coder (Step 3)**
+- Branch name and PR number
+- Wave plan with implementation order
+- Design decisions from architect
+- Instruction: link each issue to PR when work begins
+
+**Coder → Tester (Step 4)**
+- PR branch with wave implementation and initial tests
+- List of acceptance criteria per issue
+
+**Tester → Orchestrator (Step 5)**
+- PR branch with complete test suite
+- Coverage assessment
+- Any defect reports (loop back to Coder if critical)
+
+**Orchestrator → Review Pipeline (Step 6)**
+- PR number for review
+- List of changed files
+
+**Review Pipeline → Architect (Step 7)**
+- Three review reports (code-review, dba-agent, security-auditor)
+- Findings with severity, location, and suggested remediation
+
+**Architect → Coder (Step 8)**
+- Triage table: Fix Now items grouped into sequential batches
+- Clear instructions per batch: files to modify, what to change, test expectations
+
+**Review Pipeline → Architect (Step 9)**
+- Round 2 review reports
+- Delta from Round 1 (new findings only)
+
+**Orchestrator → Human (Step 12)**
+- PR link, CI status, review summary
+- List of deferred items (Follow-up / Tech Debt)
+
+**Human → Documenter (Step 13)**
+- Merged commit on main
+
+**Documenter → Orchestrator (Step 14)**
+- Updated MEMORY.md, CHANGELOG
+- Closed issues and milestone
+- List of follow-up issues created
+
+## Wave-Based Implementation
+
+Issues within a milestone are grouped into **waves** based on dependencies:
+
+```
+Wave 1: Foundation (no dependencies)
+  ├── Issue A (infrastructure/models)
+  └── Issue B (independent utility)
+
+Wave 2: Core components (depends on Wave 1)
+  ├── Issue C (depends on A)
+  └── Issue D (depends on A)
+
+Wave 3: Integration (depends on Wave 2)
+  ├── Issue E (depends on C + D)
+  └── Issue F (depends on D)
+
+Wave 4: Orchestration + Testing (depends on all above)
+  ├── Issue G (orchestrator - depends on C, D, E, F)
+  └── Issue H (integration tests - depends on G)
+```
+
+### Wave Rules
+
+1. **All issues in a wave can be implemented in parallel** (if using separate files), but
+   **coder agents must be dispatched sequentially** to avoid git conflicts in the shared
+   working directory.
+2. **Each wave produces a commit** (or small group of commits) that compiles and passes tests.
+3. **Link each issue to the PR** when work begins on that issue, not when the wave completes.
+4. **Run `dotnet test` after each wave** to catch regressions early.
+5. **Never start a wave until the previous wave's tests pass.**
+
+## Review Pipeline
+
+The review pipeline replaces GitHub Copilot PR reviews with internal specialized agents:
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Step 6: Launch three agents IN PARALLEL             │
+│                                                      │
+│  ┌──────────────┐ ┌──────────────┐ ┌──────────────┐ │
+│  │ code-review  │ │  dba-agent   │ │  security-   │ │
+│  │    agent     │ │              │ │   auditor    │ │
+│  └──────┬───────┘ └──────┬───────┘ └──────┬───────┘ │
+│         │                │                │          │
+│         └────────┬───────┴────────┬───────┘          │
+│                  ▼                                    │
+│  Step 7: Architect triages all findings               │
+│          → Fix Now / Follow-up / Tech Debt            │
+│                  │                                    │
+│                  ▼                                    │
+│  Step 8: Coder agents fix (SEQUENTIALLY)              │
+│                  │                                    │
+│                  ▼                                    │
+│  Step 9: Round 2 review (same 3 agents)               │
+│                  │                                    │
+│                  ▼                                    │
+│  Step 10: Architect validates (loop if needed, max 3) │
+└─────────────────────────────────────────────────────┘
+```
+
+### Review Pipeline Rules
+
+1. **Always run all three agents** — even if the milestone has no database changes (the DBA
+   agent may catch issues in SQL string construction or connection handling).
+2. **Architect triages findings** — coders do not self-triage. The architect determines what
+   must be fixed now vs. deferred.
+3. **Coder agents are dispatched sequentially** — never in parallel. Each agent gets explicit
+   file-level instructions and must not create new branches or push.
+4. **Budget for 2 review rounds** — fixes can introduce new issues. A third round is the
+   maximum before escalating to the human.
+5. **No unresolved high/critical findings** may remain when the PR is marked ready for merge.
+
+## Milestone Lifecycle
+
+```
+┌───────────────┐
+│ Milestone     │──► Create branch `milestone/<name>`
+│ exists in GH  │──► Open Draft PR linking all issues
+└───────┬───────┘
+        │
+        ▼
+┌───────────────┐
+│ Implementation│──► Waves 1..N with issue linking
+│ (Steps 1-5)   │──► Tests pass after each wave
+└───────┬───────┘
+        │
+        ▼
+┌───────────────┐
+│ Review +      │──► Parallel review pipeline
+│ Hardening     │──► Architect triage + coder fixes
+│ (Steps 6-11)  │──► Up to 3 review rounds
+└───────┬───────┘
+        │
+        ▼
+┌───────────────┐
+│ Merge +       │──► Human approves merge
+│ Closeout      │──► Close all issues + milestone
+│ (Steps 12-14) │──► Update MEMORY.md + CHANGELOG
+                │──► Create follow-up issues for deferred items
+└───────────────┘
+```
+
+## Completion Criteria
+
+- All issues in the milestone are implemented, tested, reviewed, and merged.
+- No unresolved security findings at high or critical severity.
+- All CI checks pass on the merged code.
+- MEMORY.md updated with lessons learned and architecture additions.
+- CHANGELOG updated with milestone summary.
+- Milestone closed in GitHub.
+- Follow-up issues created for deferred findings (Follow-up and Tech Debt categories).
+- Workflow state file updated to `completed`.
+
+## Notes
+
+- **Review loops**: If Round 2 introduces new Fix Now items, loop back to Step 8. Maximum
+  3 rounds total before escalating to the human. This prevents infinite review cycles.
+- **Sequential coder dispatch**: Parallel coder agents sharing one working directory cause
+  git conflicts. Always dispatch sequentially, verify each agent's work, then dispatch next.
+- **Issue linking convention**: Link each issue to the PR as soon as work begins on that
+  issue — don't batch link at the end. This provides real-time traceability.
+- **Scope control**: If the architect identifies scope creep during review, deferred items
+  go to follow-up issues — never expand the PR scope mid-review.
+- **Tester role**: The tester reviews coverage and writes edge-case tests AFTER the coder
+  finishes each wave. This catches gaps the coder missed. The tester does NOT block wave
+  progression — they work on the previous wave's tests while the coder starts the next wave.
+- **Orchestrator state**: Use `.teamwork/state/` files for workflow tracking. The state file
+  is the source of truth for where the workflow is and what has been completed.
+- **Relationship to feature-workflow**: This workflow is a superset of the feature-workflow.
+  For single-issue work, use `/feature-workflow`. For multi-issue milestones, use this.
+- **CI as gate**: The PR cannot be merged until all CI checks pass. If CI fails after fixes,
+  debug and fix before requesting human approval.

--- a/src/Scaffold.Api/Controllers/MigrationController.cs
+++ b/src/Scaffold.Api/Controllers/MigrationController.cs
@@ -21,6 +21,7 @@ public class MigrationController : ControllerBase
     private readonly ScaffoldDbContext _dbContext;
     private readonly IMigrationEngineFactory _migrationEngineFactory;
     private readonly MigrationProgressService _progressService;
+    private readonly MigrationCancellationService _cancellationService;
     private readonly ValidationEngine _validationEngine;
     private readonly IConnectionStringProtector _protector;
     private readonly IPreMigrationValidator _preMigrationValidator;
@@ -32,6 +33,7 @@ public class MigrationController : ControllerBase
         ScaffoldDbContext dbContext,
         IMigrationEngineFactory migrationEngineFactory,
         MigrationProgressService progressService,
+        MigrationCancellationService cancellationService,
         ValidationEngine validationEngine,
         IConnectionStringProtector protector,
         IPreMigrationValidator preMigrationValidator,
@@ -42,6 +44,7 @@ public class MigrationController : ControllerBase
         _dbContext = dbContext;
         _migrationEngineFactory = migrationEngineFactory;
         _progressService = progressService;
+        _cancellationService = cancellationService;
         _validationEngine = validationEngine;
         _protector = protector;
         _preMigrationValidator = preMigrationValidator;
@@ -114,7 +117,11 @@ public class MigrationController : ControllerBase
             var scopeFactory = _scopeFactory;
             var progressService = _progressService;
             var validationEngine = _validationEngine;
+            var cancellationService = _cancellationService;
             var logger = _logger;
+
+            // Register cancellation token for this migration
+            var migrationCt = cancellationService.Register(migrationId);
 
             _ = Task.Run(async () =>
             {
@@ -145,12 +152,12 @@ public class MigrationController : ControllerBase
 
                     if (bgPlan.Strategy == MigrationStrategy.ContinuousSync)
                     {
-                        await migrationEngine.StartContinuousSyncAsync(bgPlan, progressService, CancellationToken.None);
+                        await migrationEngine.StartContinuousSyncAsync(bgPlan, progressService, migrationCt);
                         // For continuous sync, the result comes from CompleteCutoverAsync later
                         return;
                     }
 
-                    result = await migrationEngine.ExecuteCutoverAsync(bgPlan, progressService, CancellationToken.None);
+                    result = await migrationEngine.ExecuteCutoverAsync(bgPlan, progressService, migrationCt);
                     result.Id = migrationId;
 
                     // Run post-migration validation
@@ -158,7 +165,7 @@ public class MigrationController : ControllerBase
                         sourceConnStr,
                         targetConnStr,
                         bgPlan.IncludedObjects,
-                        CancellationToken.None);
+                        migrationCt);
 
                     result.Validations = validationSummary.Results;
                     result.Success = result.Success && validationSummary.AllPassed;
@@ -169,6 +176,27 @@ public class MigrationController : ControllerBase
                     await db.SaveChangesAsync(CancellationToken.None);
 
                     await progressService.MigrationCompleted(migrationIdStr);
+                }
+                catch (OperationCanceledException)
+                {
+                    logger.LogInformation("Migration {MigrationId} was cancelled", migrationIdStr);
+                    // Status may already be set by the Cancel endpoint; ensure cleanup
+                    cancellationService.Unregister(migrationId);
+                    try
+                    {
+                        await using var cancelScope = scopeFactory.CreateAsyncScope();
+                        var cancelDb = cancelScope.ServiceProvider.GetRequiredService<ScaffoldDbContext>();
+                        var cancelPlan = await cancelDb.MigrationPlans.FindAsync(planId);
+                        var cancelProjectRepo = cancelScope.ServiceProvider.GetRequiredService<IProjectRepository>();
+                        var cancelProject = await cancelProjectRepo.GetByIdAsync(projectId2);
+                        if (cancelPlan is not null && cancelPlan.Status != MigrationStatus.Cancelled)
+                            cancelPlan.Status = MigrationStatus.Cancelled;
+                        if (cancelProject.Status != ProjectStatus.Failed)
+                            cancelProject.Status = ProjectStatus.Failed;
+                        await cancelDb.SaveChangesAsync(CancellationToken.None);
+                    }
+                    catch { }
+                    await progressService.MigrationFailed(migrationIdStr, "Migration was cancelled.");
                 }
                 catch (Exception ex)
                 {
@@ -187,6 +215,10 @@ public class MigrationController : ControllerBase
                     }
                     catch { }
                     await progressService.MigrationFailed(migrationIdStr, "Migration failed due to an internal error. Check server logs for details.");
+                }
+                finally
+                {
+                    cancellationService.Unregister(migrationId);
                 }
             });
 
@@ -211,6 +243,44 @@ public class MigrationController : ControllerBase
             return NotFound("Migration not found.");
 
         return Ok(result);
+    }
+
+    /// <summary>
+    /// Cancel a running migration.
+    /// </summary>
+    [HttpPost("{migrationId:guid}/cancel")]
+    public async Task<IActionResult> Cancel(Guid projectId, Guid migrationId, CancellationToken ct)
+    {
+        try
+        {
+            var project = await _projectRepository.GetByIdAsync(projectId);
+
+            if (project.MigrationPlan is null)
+                return NotFound("No migration plan found for this project.");
+
+            if (project.MigrationPlan.Status != MigrationStatus.Running)
+                return BadRequest("Only running migrations can be cancelled.");
+
+            if (project.MigrationPlan.MigrationId != migrationId)
+                return BadRequest("Migration ID does not match the active migration.");
+
+            var cancelled = _cancellationService.Cancel(migrationId);
+            if (!cancelled)
+                return BadRequest("Migration is not active or has already completed.");
+
+            // Update status
+            project.MigrationPlan.Status = MigrationStatus.Cancelled;
+            project.Status = ProjectStatus.Failed; // Cancelled = failed state for project
+            await _dbContext.SaveChangesAsync(ct);
+
+            await _progressService.MigrationFailed(migrationId.ToString(), "Migration was cancelled by user.");
+
+            return Ok(new { Message = "Migration cancellation requested.", MigrationId = migrationId });
+        }
+        catch (KeyNotFoundException)
+        {
+            return NotFound();
+        }
     }
 
     /// <summary>

--- a/src/Scaffold.Api/Program.cs
+++ b/src/Scaffold.Api/Program.cs
@@ -56,6 +56,7 @@ builder.Services.AddControllers()
         options.JsonSerializerOptions.Converters.Add(new System.Text.Json.Serialization.JsonStringEnumConverter()));
 builder.Services.AddSignalR();
 builder.Services.AddScoped<MigrationProgressService>();
+builder.Services.AddSingleton<MigrationCancellationService>();
 builder.Services.AddHostedService<MigrationSchedulerService>();
 
 builder.Services.AddDataProtection();

--- a/src/Scaffold.Api/Program.cs
+++ b/src/Scaffold.Api/Program.cs
@@ -78,6 +78,13 @@ builder.Services.AddScoped<CrossPlatformBulkCopier>();
 builder.Services.AddScoped<PostgreSqlScriptExecutor>();
 builder.Services.AddScoped<PostgreSqlValidationEngine>();
 builder.Services.AddScoped<SqlServerToPostgreSqlMigrator>();
+// PostgreSQL same-platform migration components
+builder.Services.AddScoped<PostgreSqlSchemaExtractor>();
+builder.Services.AddScoped<PostgreSqlDdlGenerator>();
+builder.Services.AddScoped<PostgreSqlBulkCopier>();
+builder.Services.AddScoped<PostgreSqlToPostgreSqlValidationEngine>();
+builder.Services.AddScoped<AzureExtensionHandler>();
+builder.Services.AddScoped<PostgreSqlMigrator>();
 builder.Services.AddScoped<IAssessmentEngineFactory, AssessmentEngineFactory>();
 builder.Services.AddScoped<IMigrationEngineFactory, MigrationEngineFactory>();
 builder.Services.AddSingleton<ValidationEngine>();

--- a/src/Scaffold.Api/Services/MigrationCancellationService.cs
+++ b/src/Scaffold.Api/Services/MigrationCancellationService.cs
@@ -1,0 +1,54 @@
+using System.Collections.Concurrent;
+
+namespace Scaffold.Api.Services;
+
+/// <summary>
+/// Manages cancellation tokens for active migrations.
+/// Registered as singleton so all scopes share the same token store.
+/// </summary>
+public class MigrationCancellationService
+{
+    private readonly ConcurrentDictionary<Guid, CancellationTokenSource> _tokens = new();
+
+    /// <summary>
+    /// Creates and registers a CancellationTokenSource for a migration.
+    /// Returns the linked token.
+    /// </summary>
+    public CancellationToken Register(Guid migrationId)
+    {
+        var cts = new CancellationTokenSource();
+        _tokens[migrationId] = cts;
+        return cts.Token;
+    }
+
+    /// <summary>
+    /// Cancels the migration if it is registered and not already cancelled.
+    /// Returns true if cancellation was requested, false if not found.
+    /// </summary>
+    public bool Cancel(Guid migrationId)
+    {
+        if (_tokens.TryRemove(migrationId, out var cts))
+        {
+            if (!cts.IsCancellationRequested)
+                cts.Cancel();
+            cts.Dispose();
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Removes the registration for a completed migration.
+    /// Should be called in finally blocks after migration completes.
+    /// </summary>
+    public void Unregister(Guid migrationId)
+    {
+        if (_tokens.TryRemove(migrationId, out var cts))
+            cts.Dispose();
+    }
+
+    /// <summary>
+    /// Returns true if the migration is currently registered (active).
+    /// </summary>
+    public bool IsActive(Guid migrationId) => _tokens.ContainsKey(migrationId);
+}

--- a/src/Scaffold.Api/Services/MigrationEngineFactory.cs
+++ b/src/Scaffold.Api/Services/MigrationEngineFactory.cs
@@ -14,7 +14,8 @@ public class MigrationEngineFactory : IMigrationEngineFactory
     {
         _factories = new()
         {
-            [DatabasePlatform.SqlServer] = () => serviceProvider.GetRequiredService<SqlServerMigrator>()
+            [DatabasePlatform.SqlServer] = () => serviceProvider.GetRequiredService<SqlServerMigrator>(),
+            [DatabasePlatform.PostgreSql] = () => serviceProvider.GetRequiredService<PostgreSqlMigrator>()
         };
 
         _crossPlatformFactories = new()

--- a/src/Scaffold.Core/Enums/MigrationStatus.cs
+++ b/src/Scaffold.Core/Enums/MigrationStatus.cs
@@ -6,5 +6,6 @@ public enum MigrationStatus
     Scheduled,
     Running,
     Completed,
-    Failed
+    Failed,
+    Cancelled
 }

--- a/src/Scaffold.Migration/PostgreSql/AzureExtensionHandler.cs
+++ b/src/Scaffold.Migration/PostgreSql/AzureExtensionHandler.cs
@@ -1,0 +1,175 @@
+using Npgsql;
+using Scaffold.Core.Interfaces;
+using Scaffold.Migration.PostgreSql.Models;
+
+namespace Scaffold.Migration.PostgreSql;
+
+/// <summary>
+/// Handles PostgreSQL extension compatibility during PG → Azure PG migrations.
+/// Determines which extensions can be installed, skips unsupported ones with warnings,
+/// and installs extensions in dependency order.
+/// </summary>
+public class AzureExtensionHandler
+{
+    /// <summary>
+    /// Evaluates which source extensions can be migrated to Azure PG.
+    /// Returns a plan with supported extensions in dependency order and unsupported ones with warnings.
+    /// </summary>
+    public ExtensionMigrationPlan EvaluateExtensions(IReadOnlyList<string> sourceExtensions)
+    {
+        var plan = new ExtensionMigrationPlan();
+
+        foreach (var ext in sourceExtensions)
+        {
+            if (AzurePostgreSqlExtensions.IsSupported(ext))
+            {
+                plan.ToInstall.Add(ext);
+
+                if (AzurePostgreSqlExtensions.RequiresSharedPreload(ext))
+                {
+                    plan.Warnings.Add(new ExtensionWarning
+                    {
+                        ExtensionName = ext,
+                        Message = $"Extension '{ext}' requires shared_preload_libraries configuration. " +
+                                  "Ensure the Azure PG server parameter is set before installation (requires restart).",
+                        Severity = ExtensionWarningSeverity.Info
+                    });
+                }
+            }
+            else
+            {
+                plan.Skipped.Add(ext);
+                plan.Warnings.Add(new ExtensionWarning
+                {
+                    ExtensionName = ext,
+                    Message = $"Extension '{ext}' is not supported on Azure Database for PostgreSQL - Flexible Server and will be skipped.",
+                    Severity = ExtensionWarningSeverity.Warning
+                });
+            }
+        }
+
+        // Order ToInstall by dependencies: dependencies must come first
+        plan.ToInstall = OrderByDependencies(plan.ToInstall);
+
+        return plan;
+    }
+
+    /// <summary>
+    /// Installs supported extensions on the target in dependency order.
+    /// Skips unsupported extensions with warnings. Reports progress.
+    /// </summary>
+    public virtual async Task<ExtensionMigrationResult> InstallExtensionsAsync(
+        string targetConnectionString,
+        IReadOnlyList<string> sourceExtensions,
+        IProgress<MigrationProgress>? progress = null,
+        CancellationToken ct = default)
+    {
+        var plan = EvaluateExtensions(sourceExtensions);
+        var result = new ExtensionMigrationResult
+        {
+            Skipped = plan.Skipped,
+            Warnings = new List<ExtensionWarning>(plan.Warnings)
+        };
+
+        if (plan.ToInstall.Count == 0)
+        {
+            progress?.Report(new MigrationProgress
+            {
+                Phase = "ExtensionInstallation",
+                PercentComplete = 100,
+                Message = "No extensions to install."
+            });
+            return result;
+        }
+
+        await using var connection = new NpgsqlConnection(targetConnectionString);
+        await connection.OpenAsync(ct);
+
+        for (var i = 0; i < plan.ToInstall.Count; i++)
+        {
+            var ext = plan.ToInstall[i];
+            var pct = (double)(i + 1) / plan.ToInstall.Count * 100;
+
+            progress?.Report(new MigrationProgress
+            {
+                Phase = "ExtensionInstallation",
+                PercentComplete = pct,
+                Message = $"Installing extension '{ext}' ({i + 1}/{plan.ToInstall.Count})..."
+            });
+
+            try
+            {
+                var quotedExt = PgIdentifierHelper.QuoteIdentifier(ext);
+                var sql = $"CREATE EXTENSION IF NOT EXISTS {quotedExt}";
+
+                await using var cmd = new NpgsqlCommand(sql, connection);
+                cmd.CommandTimeout = 60;
+                await cmd.ExecuteNonQueryAsync(ct);
+
+                result.Installed.Add(ext);
+            }
+            catch (Exception ex)
+            {
+                result.Failed.Add(ext);
+                result.Warnings.Add(new ExtensionWarning
+                {
+                    ExtensionName = ext,
+                    Message = $"Failed to install extension '{ext}': {ex.Message}",
+                    Severity = ExtensionWarningSeverity.Error
+                });
+            }
+        }
+
+        progress?.Report(new MigrationProgress
+        {
+            Phase = "ExtensionInstallation",
+            PercentComplete = 100,
+            Message = $"Extension installation complete. Installed: {result.Installed.Count}, " +
+                      $"Skipped: {result.Skipped.Count}, Failed: {result.Failed.Count}."
+        });
+
+        return result;
+    }
+
+    /// <summary>
+    /// Orders extensions so dependencies come before dependents.
+    /// Uses a simple topological approach based on known dependency chains.
+    /// </summary>
+    internal static List<string> OrderByDependencies(List<string> extensions)
+    {
+        var extensionSet = new HashSet<string>(extensions, StringComparer.OrdinalIgnoreCase);
+        var ordered = new List<string>();
+        var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var ext in extensions)
+        {
+            Visit(ext, extensionSet, visited, ordered);
+        }
+
+        return ordered;
+    }
+
+    private static void Visit(
+        string ext,
+        HashSet<string> extensionSet,
+        HashSet<string> visited,
+        List<string> ordered)
+    {
+        if (visited.Contains(ext))
+            return;
+
+        visited.Add(ext);
+
+        // Visit dependencies first
+        var deps = AzurePostgreSqlExtensions.GetDependencies(ext);
+        foreach (var dep in deps)
+        {
+            if (extensionSet.Contains(dep))
+            {
+                Visit(dep, extensionSet, visited, ordered);
+            }
+        }
+
+        ordered.Add(ext);
+    }
+}

--- a/src/Scaffold.Migration/PostgreSql/AzurePostgreSqlExtensions.cs
+++ b/src/Scaffold.Migration/PostgreSql/AzurePostgreSqlExtensions.cs
@@ -1,0 +1,61 @@
+namespace Scaffold.Migration.PostgreSql;
+
+/// <summary>
+/// Single source of truth for Azure Database for PostgreSQL - Flexible Server
+/// supported extensions. Referenced by both Assessment (ExtensionDetector) and
+/// Migration (AzureExtensionHandler).
+/// </summary>
+public static class AzurePostgreSqlExtensions
+{
+    /// <summary>
+    /// Extensions supported on Azure PG Flexible Server as of 2024.
+    /// </summary>
+    public static readonly HashSet<string> Supported = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "address_standardizer", "address_standardizer_data_us", "amcheck", "bloom",
+        "btree_gin", "btree_gist", "citext", "cube", "dblink", "dict_int",
+        "dict_xsyn", "earthdistance", "fuzzystrmatch", "hstore", "hypopg",
+        "intagg", "intarray", "isn", "lo", "ltree", "orafce",
+        "pageinspect", "pg_buffercache", "pg_cron", "pg_freespacemap",
+        "pg_hint_plan", "pg_partman", "pg_prewarm", "pg_repack",
+        "pg_stat_statements", "pg_trgm", "pg_visibility", "pgaudit",
+        "pgcrypto", "pglogical", "pgrouting", "pgrowlocks", "pgstattuple",
+        "plpgsql", "plv8", "postgis", "postgis_raster", "postgis_sfcgal",
+        "postgis_tiger_geocoder", "postgis_topology", "postgres_fdw",
+        "semver", "sslinfo", "tablefunc", "timescaledb", "tsm_system_rows",
+        "tsm_system_time", "unaccent", "uuid-ossp", "vector"
+    };
+
+    /// <summary>
+    /// Extensions that require shared_preload_libraries configuration.
+    /// These can't simply be installed via CREATE EXTENSION — the server
+    /// parameter must be set first (requires restart on Azure).
+    /// </summary>
+    public static readonly HashSet<string> RequiresPreload = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "pg_cron", "pg_stat_statements", "pg_hint_plan", "pgaudit",
+        "pg_partman", "timescaledb", "pglogical"
+    };
+
+    /// <summary>
+    /// Known extension dependency chains. Key depends on values.
+    /// Install values before key.
+    /// </summary>
+    public static readonly Dictionary<string, string[]> Dependencies = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["postgis_raster"] = ["postgis"],
+        ["postgis_sfcgal"] = ["postgis"],
+        ["postgis_tiger_geocoder"] = ["postgis", "fuzzystrmatch"],
+        ["postgis_topology"] = ["postgis"],
+        ["address_standardizer_data_us"] = ["address_standardizer"],
+        ["earthdistance"] = ["cube"],
+        ["pgrouting"] = ["postgis"]
+    };
+
+    public static bool IsSupported(string extensionName) => Supported.Contains(extensionName);
+
+    public static bool RequiresSharedPreload(string extensionName) => RequiresPreload.Contains(extensionName);
+
+    public static string[] GetDependencies(string extensionName) =>
+        Dependencies.TryGetValue(extensionName, out var deps) ? deps : [];
+}

--- a/src/Scaffold.Migration/PostgreSql/CrossPlatformBulkCopier.cs
+++ b/src/Scaffold.Migration/PostgreSql/CrossPlatformBulkCopier.cs
@@ -2,6 +2,7 @@ using Microsoft.Data.SqlClient;
 using Npgsql;
 using NpgsqlTypes;
 using Scaffold.Core.Interfaces;
+using Scaffold.Migration.Shared;
 
 namespace Scaffold.Migration.PostgreSql;
 
@@ -296,41 +297,19 @@ public class CrossPlatformBulkCopier
     /// Quotes a table name for PostgreSQL: dbo.Users → "public"."Users".
     /// Maps "dbo" schema to "public". Escapes embedded double-quotes.
     /// </summary>
-    public static string QuotePgName(string tableName)
-    {
-        var parts = tableName.Split('.');
-        if (parts.Length == 2 &&
-            parts[0].Trim('[', ']', '"').Equals("dbo", StringComparison.OrdinalIgnoreCase))
-        {
-            parts[0] = "public";
-        }
-
-        return string.Join(".", parts.Select(p =>
-        {
-            var clean = p.Trim('[', ']', '"');
-            return $"\"{clean.Replace("\"", "\"\"")}\"";
-        }));
-    }
+    public static string QuotePgName(string tableName) => PgIdentifierHelper.QuotePgName(tableName);
 
     /// <summary>
     /// Quotes a table name for SQL Server: dbo.Users → [dbo].[Users].
     /// Escapes embedded ']' characters by doubling them to prevent SQL injection.
     /// </summary>
-    public static string QuoteSqlName(string tableName)
-    {
-        var parts = tableName.Split('.');
-        return string.Join(".", parts.Select(p =>
-        {
-            var clean = p.Trim('[', ']');
-            return $"[{clean.Replace("]", "]]")}]";
-        }));
-    }
+    public static string QuoteSqlName(string tableName) => PgIdentifierHelper.QuoteSqlName(tableName);
 
     /// <summary>
     /// Clamps a timeout value to [30, 3600], using defaultValue when value is null.
     /// </summary>
     internal static int ClampTimeout(int? value, int defaultValue)
-        => Math.Clamp(value ?? defaultValue, 30, 3600);
+        => PgIdentifierHelper.ClampTimeout(value, defaultValue);
 
     /// <summary>
     /// Topological sort (Kahn's algorithm). Parents before children.
@@ -339,36 +318,5 @@ public class CrossPlatformBulkCopier
     internal static List<string> TopologicalSort(
         IReadOnlyList<string> tableNames,
         Dictionary<string, HashSet<string>> dependsOn)
-    {
-        var inDegree = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
-        foreach (var t in tableNames) inDegree[t] = dependsOn[t].Count;
-
-        var queue = new Queue<string>(tableNames.Where(t => inDegree[t] == 0));
-        var ordered = new List<string>(tableNames.Count);
-
-        while (queue.Count > 0)
-        {
-            var current = queue.Dequeue();
-            ordered.Add(current);
-
-            foreach (var (child, parents) in dependsOn)
-            {
-                if (parents.Remove(current))
-                {
-                    inDegree[child]--;
-                    if (inDegree[child] == 0)
-                        queue.Enqueue(child);
-                }
-            }
-        }
-
-        // Append remaining (circular dependencies) in original order
-        foreach (var t in tableNames)
-        {
-            if (!ordered.Contains(t))
-                ordered.Add(t);
-        }
-
-        return ordered;
-    }
+        => TopologicalSorter.Sort(tableNames, dependsOn);
 }

--- a/src/Scaffold.Migration/PostgreSql/DdlTranslator.cs
+++ b/src/Scaffold.Migration/PostgreSql/DdlTranslator.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using System.Text.RegularExpressions;
 using Scaffold.Migration.PostgreSql.Models;
+using Scaffold.Migration.Shared;
 
 namespace Scaffold.Migration.PostgreSql;
 
@@ -192,13 +193,12 @@ public class DdlTranslator
     /// Maps a SQL Server schema name to its PostgreSQL equivalent.
     /// "dbo" becomes "public"; all others are preserved.
     /// </summary>
-    public static string MapSchema(string schema)
-        => schema.Equals("dbo", StringComparison.OrdinalIgnoreCase) ? "public" : schema;
+    public static string MapSchema(string schema) => PgIdentifierHelper.MapSchema(schema);
 
     /// <summary>
     /// Wraps an identifier in PostgreSQL double-quotes.
     /// </summary>
-    public static string QuoteIdentifier(string name) => $"\"{name.Replace("\"", "\"\"")}\"";
+    public static string QuoteIdentifier(string name) => PgIdentifierHelper.QuoteIdentifier(name);
 
     private static readonly HashSet<string> ValidReferentialActions = new(StringComparer.OrdinalIgnoreCase)
     {
@@ -283,61 +283,9 @@ public class DdlTranslator
     /// </summary>
     internal static List<TableDefinition> TopologicalSort(IReadOnlyList<TableDefinition> tables)
     {
-        var tableKeys = new HashSet<string>(
-            tables.Select(t => $"{t.Schema}.{t.TableName}"),
-            StringComparer.OrdinalIgnoreCase);
-
-        // Build adjacency: table → set of tables it depends on
-        var deps = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
-        var tableByKey = new Dictionary<string, TableDefinition>(StringComparer.OrdinalIgnoreCase);
-
-        foreach (var t in tables)
-        {
-            var key = $"{t.Schema}.{t.TableName}";
-            tableByKey[key] = t;
-            deps[key] = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-            foreach (var fk in t.ForeignKeys)
-            {
-                var refKey = $"{fk.ReferencedSchema}.{fk.ReferencedTable}";
-                // Only add dependency if the referenced table is in our set
-                // and it's not a self-reference
-                if (tableKeys.Contains(refKey) && !string.Equals(refKey, key, StringComparison.OrdinalIgnoreCase))
-                {
-                    deps[key].Add(refKey);
-                }
-            }
-        }
-
-        // Kahn's algorithm
-        var result = new List<TableDefinition>();
-        var noDeps = new Queue<string>(deps.Where(d => d.Value.Count == 0).Select(d => d.Key));
-        var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-        while (noDeps.Count > 0)
-        {
-            var key = noDeps.Dequeue();
-            if (!visited.Add(key)) continue;
-
-            result.Add(tableByKey[key]);
-
-            foreach (var (otherKey, otherDeps) in deps)
-            {
-                if (visited.Contains(otherKey)) continue;
-                otherDeps.Remove(key);
-                if (otherDeps.Count == 0)
-                    noDeps.Enqueue(otherKey);
-            }
-        }
-
-        // Add any remaining (circular dependencies) in original order
-        foreach (var t in tables)
-        {
-            var key = $"{t.Schema}.{t.TableName}";
-            if (!visited.Contains(key))
-                result.Add(t);
-        }
-
-        return result;
+        return TopologicalSorter.Sort(
+            tables,
+            t => $"{t.Schema}.{t.TableName}",
+            t => t.ForeignKeys.Select(fk => $"{fk.ReferencedSchema}.{fk.ReferencedTable}"));
     }
 }

--- a/src/Scaffold.Migration/PostgreSql/LogicalReplicationSyncEngine.cs
+++ b/src/Scaffold.Migration/PostgreSql/LogicalReplicationSyncEngine.cs
@@ -27,6 +27,7 @@ public class LogicalReplicationSyncEngine : IAsyncDisposable
     private List<string> _tableNames = [];
     private long _totalRowsSynced;
     private CancellationTokenSource? _syncCts;
+    private DateTime _migrationStartTime;
     private Task? _replicationTask;
     private LogicalReplicationConnection? _replicationConnection;
     private PgOutputReplicationSlot? _preCreatedSlot;
@@ -56,6 +57,8 @@ public class LogicalReplicationSyncEngine : IAsyncDisposable
         Guid migrationId,
         CancellationToken ct = default)
     {
+        _migrationStartTime = DateTime.UtcNow;
+
         if (string.IsNullOrWhiteSpace(sourceConnectionString))
             throw new ArgumentException("Source connection string is required.", nameof(sourceConnectionString));
         if (string.IsNullOrWhiteSpace(targetConnectionString))
@@ -141,7 +144,7 @@ public class LogicalReplicationSyncEngine : IAsyncDisposable
         if (_replicationTask is not null)
         {
             try { await _replicationTask; }
-            catch (OperationCanceledException) { }
+            catch (OperationCanceledException) { /* Expected: we cancel the replication task as part of cutover */ }
         }
 
         // Cleanup publication and slot
@@ -156,7 +159,7 @@ public class LogicalReplicationSyncEngine : IAsyncDisposable
             ProjectId = projectId,
             RowsMigrated = _totalRowsSynced,
             Success = true,
-            StartedAt = DateTime.UtcNow,
+            StartedAt = _migrationStartTime,
             CompletedAt = DateTime.UtcNow
         };
     }

--- a/src/Scaffold.Migration/PostgreSql/LogicalReplicationSyncEngine.cs
+++ b/src/Scaffold.Migration/PostgreSql/LogicalReplicationSyncEngine.cs
@@ -10,10 +10,10 @@ namespace Scaffold.Migration.PostgreSql;
 /// <summary>
 /// Uses PostgreSQL logical replication (pgoutput protocol) to perform
 /// continuous incremental sync from source PG to target Azure PG.
-/// Flow: validate wal_level → create publication → initial data load →
-/// create replication slot → stream changes → apply to target.
+/// Flow: validate wal_level → create publication → create replication slot →
+/// initial data load → stream changes → apply to target.
 /// </summary>
-public class LogicalReplicationSyncEngine
+public class LogicalReplicationSyncEngine : IAsyncDisposable
 {
     private readonly PostgreSqlBulkCopier _bulkCopier;
     private readonly IProgress<MigrationProgress>? _progress;
@@ -29,6 +29,7 @@ public class LogicalReplicationSyncEngine
     private CancellationTokenSource? _syncCts;
     private Task? _replicationTask;
     private LogicalReplicationConnection? _replicationConnection;
+    private PgOutputReplicationSlot? _preCreatedSlot;
 
     public LogicalReplicationSyncEngine(
         PostgreSqlBulkCopier bulkCopier,
@@ -46,7 +47,7 @@ public class LogicalReplicationSyncEngine
     public bool IsRunning => _replicationTask is { IsCompleted: false };
 
     /// <summary>
-    /// Validates prerequisites, performs initial load, creates publication + slot, starts streaming.
+    /// Validates prerequisites, creates publication + slot, performs initial load, starts streaming.
     /// </summary>
     public async Task StartAsync(
         string sourceConnectionString,
@@ -75,23 +76,51 @@ public class LogicalReplicationSyncEngine
         // Step 3: Create publication for specified tables
         await CreatePublicationAsync(ct);
 
-        // Step 4: Initial data load via bulk copier (snapshot-consistent)
-        _progress?.Report(new MigrationProgress
+        try
         {
-            Phase = "InitialLoad",
-            PercentComplete = 0,
-            Message = "Performing initial data load..."
-        });
+            // Step 4: Create replication slot (captures consistent snapshot LSN)
+            _replicationConnection = new LogicalReplicationConnection(_sourceConnectionString);
+            await _replicationConnection.Open(ct);
 
-        _totalRowsSynced = await _bulkCopier.CopyDataAsync(
-            _sourceConnectionString, _targetConnectionString,
-            _tableNames, _progress, ct: ct);
+            _preCreatedSlot = await _replicationConnection.CreatePgOutputReplicationSlot(
+                _slotName, slotSnapshotInitMode: LogicalSlotSnapshotInitMode.Export, cancellationToken: ct);
 
-        await _bulkCopier.ResetSequencesAsync(_targetConnectionString, ct);
+            // Step 5: Initial data load via bulk copier (snapshot-consistent)
+            _progress?.Report(new MigrationProgress
+            {
+                Phase = "InitialLoad",
+                PercentComplete = 0,
+                Message = "Performing initial data load..."
+            });
 
-        // Step 5: Create replication slot and start streaming
-        _syncCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        _replicationTask = StreamChangesAsync(_syncCts.Token);
+            _totalRowsSynced = await _bulkCopier.CopyDataAsync(
+                _sourceConnectionString, _targetConnectionString,
+                _tableNames, _progress, ct: ct);
+
+            await _bulkCopier.ResetSequencesAsync(_targetConnectionString, ct);
+
+            // Step 6: Start streaming from the pre-created slot
+            _syncCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            _replicationTask = StreamChangesAsync(_syncCts.Token);
+        }
+        catch
+        {
+            // Cleanup on failure: dispose CTS, drop slot/publication
+            if (_syncCts is not null)
+            {
+                _syncCts.Dispose();
+                _syncCts = null;
+            }
+
+            if (_replicationConnection is not null)
+            {
+                await _replicationConnection.DisposeAsync();
+                _replicationConnection = null;
+            }
+
+            await CleanupReplicationResourcesAsync(CancellationToken.None);
+            throw;
+        }
     }
 
     /// <summary>
@@ -206,37 +235,40 @@ public class LogicalReplicationSyncEngine
     }
 
     /// <summary>
-    /// Streams changes from the replication slot and applies them to target.
+    /// Streams changes from the pre-created replication slot and applies them to target.
+    /// Uses a single target connection for all apply operations.
     /// </summary>
     private async Task StreamChangesAsync(CancellationToken ct)
     {
+        NpgsqlConnection? targetConn = null;
         try
         {
-            _replicationConnection = new LogicalReplicationConnection(_sourceConnectionString);
-            await _replicationConnection.Open(ct);
+            // Open a single connection to the target for all apply operations
+            targetConn = new NpgsqlConnection(_targetConnectionString);
+            await targetConn.OpenAsync(ct);
 
-            // Create replication slot (creates a consistent snapshot point)
-            var slot = await _replicationConnection.CreatePgOutputReplicationSlot(
-                _slotName, slotSnapshotInitMode: LogicalSlotSnapshotInitMode.Export, cancellationToken: ct);
+            // Use the pre-created replication slot (already created in StartAsync)
+            var slot = _preCreatedSlot
+                ?? throw new InvalidOperationException("Replication slot was not pre-created. Call StartAsync first.");
 
             var options = new PgOutputReplicationOptions(_publicationName, protocolVersion: 1);
 
-            await foreach (var message in _replicationConnection.StartReplication(slot, options, ct))
+            await foreach (var message in _replicationConnection!.StartReplication(slot, options, ct))
             {
                 ct.ThrowIfCancellationRequested();
 
                 if (_retryPolicy is not null)
                 {
                     await _retryPolicy.ExecuteAsync(
-                        async token => await ApplyReplicationMessageAsync(message, token), ct);
+                        async token => await ApplyReplicationMessageAsync(message, targetConn, token), ct);
                 }
                 else
                 {
-                    await ApplyReplicationMessageAsync(message, ct);
+                    await ApplyReplicationMessageAsync(message, targetConn, ct);
                 }
 
                 // Acknowledge the message
-                _replicationConnection.SetReplicationStatus(message.WalEnd);
+                _replicationConnection!.SetReplicationStatus(message.WalEnd);
             }
         }
         catch (OperationCanceledException)
@@ -245,6 +277,11 @@ public class LogicalReplicationSyncEngine
         }
         finally
         {
+            if (targetConn is not null)
+            {
+                await targetConn.DisposeAsync();
+            }
+
             if (_replicationConnection is not null)
             {
                 await _replicationConnection.DisposeAsync();
@@ -258,27 +295,28 @@ public class LogicalReplicationSyncEngine
     /// </summary>
     internal virtual async Task ApplyReplicationMessageAsync(
         PgOutputReplicationMessage message,
+        NpgsqlConnection targetConn,
         CancellationToken ct)
     {
         switch (message)
         {
             case InsertMessage insert:
-                await ApplyInsertAsync(insert, ct);
+                await ApplyInsertAsync(insert, targetConn, ct);
                 break;
             case UpdateMessage update:
-                await ApplyUpdateAsync(update, ct);
+                await ApplyUpdateAsync(update, targetConn, ct);
                 break;
             case KeyDeleteMessage keyDelete:
-                await ApplyKeyDeleteAsync(keyDelete, ct);
+                await ApplyKeyDeleteAsync(keyDelete, targetConn, ct);
                 break;
             case FullDeleteMessage fullDelete:
-                await ApplyFullDeleteAsync(fullDelete, ct);
+                await ApplyFullDeleteAsync(fullDelete, targetConn, ct);
                 break;
             // BeginMessage, CommitMessage, RelationMessage — no action needed for target
         }
     }
 
-    private async Task ApplyInsertAsync(InsertMessage insert, CancellationToken ct)
+    private async Task ApplyInsertAsync(InsertMessage insert, NpgsqlConnection targetConn, CancellationToken ct)
     {
         var tableName = $"{insert.Relation.Namespace}.{insert.Relation.RelationName}";
         var pgTable = PgIdentifierHelper.QuotePgName(tableName);
@@ -288,10 +326,8 @@ public class LogicalReplicationSyncEngine
         var paramNames = string.Join(", ",
             columns.Select((_, i) => $"@p{i}"));
 
-        await using var conn = new NpgsqlConnection(_targetConnectionString);
-        await conn.OpenAsync(ct);
         await using var cmd = new NpgsqlCommand(
-            $"INSERT INTO {pgTable} ({colNames}) VALUES ({paramNames}) ON CONFLICT DO NOTHING", conn);
+            $"INSERT INTO {pgTable} ({colNames}) VALUES ({paramNames}) ON CONFLICT DO NOTHING", targetConn);
 
         int i = 0;
         await foreach (var value in insert.NewRow)
@@ -305,7 +341,7 @@ public class LogicalReplicationSyncEngine
         Interlocked.Increment(ref _totalRowsSynced);
     }
 
-    private async Task ApplyUpdateAsync(UpdateMessage update, CancellationToken ct)
+    private async Task ApplyUpdateAsync(UpdateMessage update, NpgsqlConnection targetConn, CancellationToken ct)
     {
         var tableName = $"{update.Relation.Namespace}.{update.Relation.RelationName}";
         var pgTable = PgIdentifierHelper.QuotePgName(tableName);
@@ -320,9 +356,6 @@ public class LogicalReplicationSyncEngine
             .Where(c => c.Flags.HasFlag(RelationMessage.Column.ColumnFlags.PartOfKey))
             .Select(c => PgIdentifierHelper.QuoteIdentifier(c.ColumnName))
             .ToList();
-
-        await using var conn = new NpgsqlConnection(_targetConnectionString);
-        await conn.OpenAsync(ct);
 
         string sql;
         if (pkColumns.Count > 0)
@@ -346,7 +379,7 @@ public class LogicalReplicationSyncEngine
             sql = $"INSERT INTO {pgTable} ({colNames}) VALUES ({paramNames}) ON CONFLICT DO NOTHING";
         }
 
-        await using var cmd = new NpgsqlCommand(sql, conn);
+        await using var cmd = new NpgsqlCommand(sql, targetConn);
 
         int i = 0;
         await foreach (var value in update.NewRow)
@@ -360,7 +393,7 @@ public class LogicalReplicationSyncEngine
         Interlocked.Increment(ref _totalRowsSynced);
     }
 
-    private async Task ApplyKeyDeleteAsync(KeyDeleteMessage delete, CancellationToken ct)
+    private async Task ApplyKeyDeleteAsync(KeyDeleteMessage delete, NpgsqlConnection targetConn, CancellationToken ct)
     {
         var tableName = $"{delete.Relation.Namespace}.{delete.Relation.RelationName}";
         var pgTable = PgIdentifierHelper.QuotePgName(tableName);
@@ -374,12 +407,10 @@ public class LogicalReplicationSyncEngine
         if (keyColumns.Count == 0) return; // Can't delete without key identity
 
         var whereClauses = keyColumns.Select((c, i) =>
-            $"{PgIdentifierHelper.QuoteIdentifier(c.ColumnName)} = @p{i}");
+            $"{PgIdentifierHelper.QuoteIdentifier(c.ColumnName)} IS NOT DISTINCT FROM @p{i}");
         var sql = $"DELETE FROM {pgTable} WHERE {string.Join(" AND ", whereClauses)}";
 
-        await using var conn = new NpgsqlConnection(_targetConnectionString);
-        await conn.OpenAsync(ct);
-        await using var cmd = new NpgsqlCommand(sql, conn);
+        await using var cmd = new NpgsqlCommand(sql, targetConn);
 
         int i = 0;
         await foreach (var value in delete.Key)
@@ -392,7 +423,7 @@ public class LogicalReplicationSyncEngine
         await cmd.ExecuteNonQueryAsync(ct);
     }
 
-    private async Task ApplyFullDeleteAsync(FullDeleteMessage delete, CancellationToken ct)
+    private async Task ApplyFullDeleteAsync(FullDeleteMessage delete, NpgsqlConnection targetConn, CancellationToken ct)
     {
         var tableName = $"{delete.Relation.Namespace}.{delete.Relation.RelationName}";
         var pgTable = PgIdentifierHelper.QuotePgName(tableName);
@@ -400,12 +431,10 @@ public class LogicalReplicationSyncEngine
 
         // Use all columns for WHERE clause (REPLICA IDENTITY FULL)
         var whereClauses = columns.Select((c, i) =>
-            $"{PgIdentifierHelper.QuoteIdentifier(c.ColumnName)} = @p{i}");
+            $"{PgIdentifierHelper.QuoteIdentifier(c.ColumnName)} IS NOT DISTINCT FROM @p{i}");
         var sql = $"DELETE FROM {pgTable} WHERE {string.Join(" AND ", whereClauses)}";
 
-        await using var conn = new NpgsqlConnection(_targetConnectionString);
-        await conn.OpenAsync(ct);
-        await using var cmd = new NpgsqlCommand(sql, conn);
+        await using var cmd = new NpgsqlCommand(sql, targetConn);
 
         int i = 0;
         await foreach (var value in delete.OldRow)
@@ -426,11 +455,12 @@ public class LogicalReplicationSyncEngine
         await using var conn = new NpgsqlConnection(_sourceConnectionString);
         await conn.OpenAsync(ct);
 
-        // Drop replication slot
+        // Drop replication slot (parameterized to prevent SQL injection)
         try
         {
             await using var dropSlotCmd = new NpgsqlCommand(
-                $"SELECT pg_drop_replication_slot('{_slotName}')", conn);
+                "SELECT pg_drop_replication_slot(@slot)", conn);
+            dropSlotCmd.Parameters.AddWithValue("slot", _slotName);
             await dropSlotCmd.ExecuteNonQueryAsync(ct);
         }
         catch (PostgresException ex) when (ex.SqlState == "42704") // slot does not exist
@@ -469,5 +499,48 @@ public class LogicalReplicationSyncEngine
     {
         var raw = $"scaffold_pub_{migrationId:N}";
         return raw.Length > 63 ? raw[..63] : raw;
+    }
+
+    /// <summary>
+    /// Disposes replication resources: cancels streaming, awaits completion,
+    /// disposes connection, and cleans up slot/publication.
+    /// </summary>
+    public async ValueTask DisposeAsync()
+    {
+        if (_syncCts is not null)
+        {
+            try { await _syncCts.CancelAsync(); }
+            catch { /* best effort */ }
+        }
+
+        if (_replicationTask is not null)
+        {
+            try { await _replicationTask; }
+            catch (OperationCanceledException) { }
+            catch { /* best effort */ }
+        }
+
+        if (_replicationConnection is not null)
+        {
+            await _replicationConnection.DisposeAsync();
+            _replicationConnection = null;
+        }
+
+        if (_syncCts is not null)
+        {
+            _syncCts.Dispose();
+            _syncCts = null;
+        }
+
+        try
+        {
+            await CleanupReplicationResourcesAsync(CancellationToken.None);
+        }
+        catch
+        {
+            // Best effort cleanup during dispose
+        }
+
+        GC.SuppressFinalize(this);
     }
 }

--- a/src/Scaffold.Migration/PostgreSql/LogicalReplicationSyncEngine.cs
+++ b/src/Scaffold.Migration/PostgreSql/LogicalReplicationSyncEngine.cs
@@ -1,0 +1,462 @@
+using Npgsql;
+using Npgsql.Replication;
+using Npgsql.Replication.PgOutput;
+using Npgsql.Replication.PgOutput.Messages;
+using Scaffold.Core.Interfaces;
+using Scaffold.Core.Models;
+
+namespace Scaffold.Migration.PostgreSql;
+
+/// <summary>
+/// Uses PostgreSQL logical replication (pgoutput protocol) to perform
+/// continuous incremental sync from source PG to target Azure PG.
+/// Flow: validate wal_level → create publication → initial data load →
+/// create replication slot → stream changes → apply to target.
+/// </summary>
+public class LogicalReplicationSyncEngine
+{
+    private readonly PostgreSqlBulkCopier _bulkCopier;
+    private readonly IProgress<MigrationProgress>? _progress;
+    private readonly TimeSpan _pollInterval;
+
+    private string _sourceConnectionString = string.Empty;
+    private string _targetConnectionString = string.Empty;
+    private string _publicationName = string.Empty;
+    private string _slotName = string.Empty;
+    private List<string> _tableNames = [];
+    private long _totalRowsSynced;
+    private CancellationTokenSource? _syncCts;
+    private Task? _replicationTask;
+    private LogicalReplicationConnection? _replicationConnection;
+
+    public LogicalReplicationSyncEngine(
+        PostgreSqlBulkCopier bulkCopier,
+        IProgress<MigrationProgress>? progress = null,
+        TimeSpan? pollInterval = null)
+    {
+        _bulkCopier = bulkCopier ?? throw new ArgumentNullException(nameof(bulkCopier));
+        _progress = progress;
+        _pollInterval = pollInterval ?? TimeSpan.FromSeconds(1);
+    }
+
+    public long TotalRowsSynced => _totalRowsSynced;
+    public bool IsRunning => _replicationTask is { IsCompleted: false };
+
+    /// <summary>
+    /// Validates prerequisites, performs initial load, creates publication + slot, starts streaming.
+    /// </summary>
+    public async Task StartAsync(
+        string sourceConnectionString,
+        string targetConnectionString,
+        IReadOnlyList<string> tableNames,
+        Guid migrationId,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(sourceConnectionString))
+            throw new ArgumentException("Source connection string is required.", nameof(sourceConnectionString));
+        if (string.IsNullOrWhiteSpace(targetConnectionString))
+            throw new ArgumentException("Target connection string is required.", nameof(targetConnectionString));
+
+        _sourceConnectionString = sourceConnectionString;
+        _targetConnectionString = targetConnectionString;
+        _tableNames = tableNames.ToList();
+        _publicationName = GeneratePublicationName(migrationId);
+        _slotName = GenerateSlotName(migrationId);
+
+        // Step 1: Validate wal_level = logical
+        await ValidateWalLevelAsync(ct);
+
+        // Step 2: Ensure REPLICA IDENTITY is set for tables without PKs
+        await EnsureReplicaIdentityAsync(ct);
+
+        // Step 3: Create publication for specified tables
+        await CreatePublicationAsync(ct);
+
+        // Step 4: Initial data load via bulk copier (snapshot-consistent)
+        _progress?.Report(new MigrationProgress
+        {
+            Phase = "InitialLoad",
+            PercentComplete = 0,
+            Message = "Performing initial data load..."
+        });
+
+        _totalRowsSynced = await _bulkCopier.CopyDataAsync(
+            _sourceConnectionString, _targetConnectionString,
+            _tableNames, _progress, ct: ct);
+
+        await _bulkCopier.ResetSequencesAsync(_targetConnectionString, ct);
+
+        // Step 5: Create replication slot and start streaming
+        _syncCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        _replicationTask = StreamChangesAsync(_syncCts.Token);
+    }
+
+    /// <summary>
+    /// Stops replication, applies final changes, validates, returns result.
+    /// </summary>
+    public async Task<MigrationResult> CompleteCutoverAsync(
+        Guid projectId,
+        CancellationToken ct = default)
+    {
+        if (_syncCts is null)
+        {
+            throw new InvalidOperationException(
+                "Cannot complete cutover before starting continuous sync. Call StartAsync first.");
+        }
+
+        // Stop the replication stream
+        await _syncCts.CancelAsync();
+        if (_replicationTask is not null)
+        {
+            try { await _replicationTask; }
+            catch (OperationCanceledException) { }
+        }
+
+        // Cleanup publication and slot
+        await CleanupReplicationResourcesAsync(ct);
+
+        // Reset sequences one final time
+        await _bulkCopier.ResetSequencesAsync(_targetConnectionString, ct);
+
+        return new MigrationResult
+        {
+            Id = Guid.NewGuid(),
+            ProjectId = projectId,
+            RowsMigrated = _totalRowsSynced,
+            Success = true,
+            StartedAt = DateTime.UtcNow,
+            CompletedAt = DateTime.UtcNow
+        };
+    }
+
+    /// <summary>
+    /// Validates that source PG has wal_level = logical.
+    /// </summary>
+    internal virtual async Task ValidateWalLevelAsync(CancellationToken ct)
+    {
+        await using var conn = new NpgsqlConnection(_sourceConnectionString);
+        await conn.OpenAsync(ct);
+        await using var cmd = new NpgsqlCommand("SHOW wal_level", conn);
+        var walLevel = (string)(await cmd.ExecuteScalarAsync(ct))!;
+        if (!string.Equals(walLevel, "logical", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                $"Source PostgreSQL wal_level is '{walLevel}', but 'logical' is required for replication. " +
+                "Set wal_level = logical in postgresql.conf and restart the server.");
+        }
+    }
+
+    /// <summary>
+    /// Ensures tables without PKs have REPLICA IDENTITY FULL.
+    /// </summary>
+    internal virtual async Task EnsureReplicaIdentityAsync(CancellationToken ct)
+    {
+        await using var conn = new NpgsqlConnection(_sourceConnectionString);
+        await conn.OpenAsync(ct);
+
+        foreach (var table in _tableNames)
+        {
+            var pgName = PgIdentifierHelper.QuotePgName(table);
+            // Check if table has a PK
+            var parts = table.Split('.');
+            var schema = parts.Length == 2 ? parts[0].Trim('"') : "public";
+            var tableName = parts.Length == 2 ? parts[1].Trim('"') : parts[0].Trim('"');
+
+            await using var checkCmd = new NpgsqlCommand(@"
+                SELECT COUNT(*) FROM pg_constraint c
+                JOIN pg_class t ON c.conrelid = t.oid
+                JOIN pg_namespace n ON t.relnamespace = n.oid
+                WHERE c.contype = 'p' AND n.nspname = @schema AND t.relname = @table", conn);
+            checkCmd.Parameters.AddWithValue("schema", schema);
+            checkCmd.Parameters.AddWithValue("table", tableName);
+
+            var pkCount = (long)(await checkCmd.ExecuteScalarAsync(ct))!;
+            if (pkCount == 0)
+            {
+                // Set REPLICA IDENTITY FULL for tables without PKs
+                await using var alterCmd = new NpgsqlCommand(
+                    $"ALTER TABLE {pgName} REPLICA IDENTITY FULL", conn);
+                await alterCmd.ExecuteNonQueryAsync(ct);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Creates a publication on the source for the specified tables.
+    /// </summary>
+    internal virtual async Task CreatePublicationAsync(CancellationToken ct)
+    {
+        await using var conn = new NpgsqlConnection(_sourceConnectionString);
+        await conn.OpenAsync(ct);
+
+        // Drop if exists (for re-runnable migrations)
+        await using (var dropCmd = new NpgsqlCommand(
+            $"DROP PUBLICATION IF EXISTS {PgIdentifierHelper.QuoteIdentifier(_publicationName)}", conn))
+        {
+            await dropCmd.ExecuteNonQueryAsync(ct);
+        }
+
+        var tableList = string.Join(", ", _tableNames.Select(PgIdentifierHelper.QuotePgName));
+        await using var createCmd = new NpgsqlCommand(
+            $"CREATE PUBLICATION {PgIdentifierHelper.QuoteIdentifier(_publicationName)} FOR TABLE {tableList}", conn);
+        await createCmd.ExecuteNonQueryAsync(ct);
+    }
+
+    /// <summary>
+    /// Streams changes from the replication slot and applies them to target.
+    /// </summary>
+    private async Task StreamChangesAsync(CancellationToken ct)
+    {
+        try
+        {
+            _replicationConnection = new LogicalReplicationConnection(_sourceConnectionString);
+            await _replicationConnection.Open(ct);
+
+            // Create replication slot (creates a consistent snapshot point)
+            var slot = await _replicationConnection.CreatePgOutputReplicationSlot(
+                _slotName, slotSnapshotInitMode: LogicalSlotSnapshotInitMode.Export, cancellationToken: ct);
+
+            var options = new PgOutputReplicationOptions(_publicationName, protocolVersion: 1);
+
+            await foreach (var message in _replicationConnection.StartReplication(slot, options, ct))
+            {
+                ct.ThrowIfCancellationRequested();
+
+                await ApplyReplicationMessageAsync(message, ct);
+
+                // Acknowledge the message
+                _replicationConnection.SetReplicationStatus(message.WalEnd);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Normal shutdown
+        }
+        finally
+        {
+            if (_replicationConnection is not null)
+            {
+                await _replicationConnection.DisposeAsync();
+                _replicationConnection = null;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Applies a single replication message to the target database.
+    /// </summary>
+    internal virtual async Task ApplyReplicationMessageAsync(
+        PgOutputReplicationMessage message,
+        CancellationToken ct)
+    {
+        switch (message)
+        {
+            case InsertMessage insert:
+                await ApplyInsertAsync(insert, ct);
+                break;
+            case UpdateMessage update:
+                await ApplyUpdateAsync(update, ct);
+                break;
+            case KeyDeleteMessage keyDelete:
+                await ApplyKeyDeleteAsync(keyDelete, ct);
+                break;
+            case FullDeleteMessage fullDelete:
+                await ApplyFullDeleteAsync(fullDelete, ct);
+                break;
+            // BeginMessage, CommitMessage, RelationMessage — no action needed for target
+        }
+    }
+
+    private async Task ApplyInsertAsync(InsertMessage insert, CancellationToken ct)
+    {
+        var tableName = $"{insert.Relation.Namespace}.{insert.Relation.RelationName}";
+        var pgTable = PgIdentifierHelper.QuotePgName(tableName);
+        var columns = insert.Relation.Columns;
+        var colNames = string.Join(", ",
+            columns.Select(c => PgIdentifierHelper.QuoteIdentifier(c.ColumnName)));
+        var paramNames = string.Join(", ",
+            columns.Select((_, i) => $"@p{i}"));
+
+        await using var conn = new NpgsqlConnection(_targetConnectionString);
+        await conn.OpenAsync(ct);
+        await using var cmd = new NpgsqlCommand(
+            $"INSERT INTO {pgTable} ({colNames}) VALUES ({paramNames}) ON CONFLICT DO NOTHING", conn);
+
+        int i = 0;
+        await foreach (var value in insert.NewRow)
+        {
+            var val = value.IsDBNull ? DBNull.Value : await value.Get<object>(ct);
+            cmd.Parameters.AddWithValue($"p{i}", val);
+            i++;
+        }
+
+        await cmd.ExecuteNonQueryAsync(ct);
+        Interlocked.Increment(ref _totalRowsSynced);
+    }
+
+    private async Task ApplyUpdateAsync(UpdateMessage update, CancellationToken ct)
+    {
+        var tableName = $"{update.Relation.Namespace}.{update.Relation.RelationName}";
+        var pgTable = PgIdentifierHelper.QuotePgName(tableName);
+        var columns = update.Relation.Columns;
+        var colNames = string.Join(", ",
+            columns.Select(c => PgIdentifierHelper.QuoteIdentifier(c.ColumnName)));
+        var paramNames = string.Join(", ",
+            columns.Select((_, i) => $"@p{i}"));
+
+        // Find PK columns (PartOfKey flag in pgoutput)
+        var pkColumns = columns
+            .Where(c => c.Flags.HasFlag(RelationMessage.Column.ColumnFlags.PartOfKey))
+            .Select(c => PgIdentifierHelper.QuoteIdentifier(c.ColumnName))
+            .ToList();
+
+        await using var conn = new NpgsqlConnection(_targetConnectionString);
+        await conn.OpenAsync(ct);
+
+        string sql;
+        if (pkColumns.Count > 0)
+        {
+            var nonKeyColumns = columns
+                .Where(c => !c.Flags.HasFlag(RelationMessage.Column.ColumnFlags.PartOfKey))
+                .ToList();
+
+            var updateSet = nonKeyColumns.Count > 0
+                ? string.Join(", ", nonKeyColumns.Select(c =>
+                    $"{PgIdentifierHelper.QuoteIdentifier(c.ColumnName)} = EXCLUDED.{PgIdentifierHelper.QuoteIdentifier(c.ColumnName)}"))
+                : string.Join(", ", columns.Select(c =>
+                    $"{PgIdentifierHelper.QuoteIdentifier(c.ColumnName)} = EXCLUDED.{PgIdentifierHelper.QuoteIdentifier(c.ColumnName)}"));
+
+            sql = $"INSERT INTO {pgTable} ({colNames}) VALUES ({paramNames}) " +
+                  $"ON CONFLICT ({string.Join(", ", pkColumns)}) DO UPDATE SET {updateSet}";
+        }
+        else
+        {
+            // No PK — just try insert, ignore conflicts
+            sql = $"INSERT INTO {pgTable} ({colNames}) VALUES ({paramNames}) ON CONFLICT DO NOTHING";
+        }
+
+        await using var cmd = new NpgsqlCommand(sql, conn);
+
+        int i = 0;
+        await foreach (var value in update.NewRow)
+        {
+            var val = value.IsDBNull ? DBNull.Value : await value.Get<object>(ct);
+            cmd.Parameters.AddWithValue($"p{i}", val);
+            i++;
+        }
+
+        await cmd.ExecuteNonQueryAsync(ct);
+        Interlocked.Increment(ref _totalRowsSynced);
+    }
+
+    private async Task ApplyKeyDeleteAsync(KeyDeleteMessage delete, CancellationToken ct)
+    {
+        var tableName = $"{delete.Relation.Namespace}.{delete.Relation.RelationName}";
+        var pgTable = PgIdentifierHelper.QuotePgName(tableName);
+        var columns = delete.Relation.Columns;
+
+        // Use key columns for WHERE clause
+        var keyColumns = columns
+            .Where(c => c.Flags.HasFlag(RelationMessage.Column.ColumnFlags.PartOfKey))
+            .ToList();
+
+        if (keyColumns.Count == 0) return; // Can't delete without key identity
+
+        var whereClauses = keyColumns.Select((c, i) =>
+            $"{PgIdentifierHelper.QuoteIdentifier(c.ColumnName)} = @p{i}");
+        var sql = $"DELETE FROM {pgTable} WHERE {string.Join(" AND ", whereClauses)}";
+
+        await using var conn = new NpgsqlConnection(_targetConnectionString);
+        await conn.OpenAsync(ct);
+        await using var cmd = new NpgsqlCommand(sql, conn);
+
+        int i = 0;
+        await foreach (var value in delete.Key)
+        {
+            var val = value.IsDBNull ? DBNull.Value : await value.Get<object>(ct);
+            cmd.Parameters.AddWithValue($"p{i}", val);
+            i++;
+        }
+
+        await cmd.ExecuteNonQueryAsync(ct);
+    }
+
+    private async Task ApplyFullDeleteAsync(FullDeleteMessage delete, CancellationToken ct)
+    {
+        var tableName = $"{delete.Relation.Namespace}.{delete.Relation.RelationName}";
+        var pgTable = PgIdentifierHelper.QuotePgName(tableName);
+        var columns = delete.Relation.Columns;
+
+        // Use all columns for WHERE clause (REPLICA IDENTITY FULL)
+        var whereClauses = columns.Select((c, i) =>
+            $"{PgIdentifierHelper.QuoteIdentifier(c.ColumnName)} = @p{i}");
+        var sql = $"DELETE FROM {pgTable} WHERE {string.Join(" AND ", whereClauses)}";
+
+        await using var conn = new NpgsqlConnection(_targetConnectionString);
+        await conn.OpenAsync(ct);
+        await using var cmd = new NpgsqlCommand(sql, conn);
+
+        int i = 0;
+        await foreach (var value in delete.OldRow)
+        {
+            var val = value.IsDBNull ? DBNull.Value : await value.Get<object>(ct);
+            cmd.Parameters.AddWithValue($"p{i}", val);
+            i++;
+        }
+
+        await cmd.ExecuteNonQueryAsync(ct);
+    }
+
+    /// <summary>
+    /// Cleans up replication slot and publication on the source database.
+    /// </summary>
+    internal virtual async Task CleanupReplicationResourcesAsync(CancellationToken ct)
+    {
+        await using var conn = new NpgsqlConnection(_sourceConnectionString);
+        await conn.OpenAsync(ct);
+
+        // Drop replication slot
+        try
+        {
+            await using var dropSlotCmd = new NpgsqlCommand(
+                $"SELECT pg_drop_replication_slot('{_slotName}')", conn);
+            await dropSlotCmd.ExecuteNonQueryAsync(ct);
+        }
+        catch (PostgresException ex) when (ex.SqlState == "42704") // slot does not exist
+        {
+            // Already cleaned up — safe to ignore
+        }
+
+        // Drop publication
+        try
+        {
+            await using var dropPubCmd = new NpgsqlCommand(
+                $"DROP PUBLICATION IF EXISTS {PgIdentifierHelper.QuoteIdentifier(_publicationName)}", conn);
+            await dropPubCmd.ExecuteNonQueryAsync(ct);
+        }
+        catch (PostgresException)
+        {
+            // Best effort cleanup
+        }
+    }
+
+    /// <summary>
+    /// Generates a replication slot name from a migration ID.
+    /// PG slot names: lowercase, max 63 chars, [a-z0-9_].
+    /// </summary>
+    internal static string GenerateSlotName(Guid migrationId)
+    {
+        var raw = $"scaffold_{migrationId:N}";
+        return raw.Length > 63 ? raw[..63] : raw;
+    }
+
+    /// <summary>
+    /// Generates a publication name from a migration ID.
+    /// PG identifiers: max 63 chars.
+    /// </summary>
+    internal static string GeneratePublicationName(Guid migrationId)
+    {
+        var raw = $"scaffold_pub_{migrationId:N}";
+        return raw.Length > 63 ? raw[..63] : raw;
+    }
+}

--- a/src/Scaffold.Migration/PostgreSql/LogicalReplicationSyncEngine.cs
+++ b/src/Scaffold.Migration/PostgreSql/LogicalReplicationSyncEngine.cs
@@ -18,6 +18,7 @@ public class LogicalReplicationSyncEngine
     private readonly PostgreSqlBulkCopier _bulkCopier;
     private readonly IProgress<MigrationProgress>? _progress;
     private readonly TimeSpan _pollInterval;
+    private readonly ReplicationRetryPolicy? _retryPolicy;
 
     private string _sourceConnectionString = string.Empty;
     private string _targetConnectionString = string.Empty;
@@ -32,11 +33,13 @@ public class LogicalReplicationSyncEngine
     public LogicalReplicationSyncEngine(
         PostgreSqlBulkCopier bulkCopier,
         IProgress<MigrationProgress>? progress = null,
-        TimeSpan? pollInterval = null)
+        TimeSpan? pollInterval = null,
+        ReplicationRetryPolicy? retryPolicy = null)
     {
         _bulkCopier = bulkCopier ?? throw new ArgumentNullException(nameof(bulkCopier));
         _progress = progress;
         _pollInterval = pollInterval ?? TimeSpan.FromSeconds(1);
+        _retryPolicy = retryPolicy;
     }
 
     public long TotalRowsSynced => _totalRowsSynced;
@@ -222,7 +225,15 @@ public class LogicalReplicationSyncEngine
             {
                 ct.ThrowIfCancellationRequested();
 
-                await ApplyReplicationMessageAsync(message, ct);
+                if (_retryPolicy is not null)
+                {
+                    await _retryPolicy.ExecuteAsync(
+                        async token => await ApplyReplicationMessageAsync(message, token), ct);
+                }
+                else
+                {
+                    await ApplyReplicationMessageAsync(message, ct);
+                }
 
                 // Acknowledge the message
                 _replicationConnection.SetReplicationStatus(message.WalEnd);

--- a/src/Scaffold.Migration/PostgreSql/Models/ExtensionMigrationResult.cs
+++ b/src/Scaffold.Migration/PostgreSql/Models/ExtensionMigrationResult.cs
@@ -1,0 +1,58 @@
+namespace Scaffold.Migration.PostgreSql.Models;
+
+/// <summary>
+/// Plan for migrating PostgreSQL extensions to Azure Flexible Server.
+/// Separates supported extensions (to install) from unsupported ones (to skip).
+/// </summary>
+public class ExtensionMigrationPlan
+{
+    /// <summary>Supported extensions that will be installed, in dependency order.</summary>
+    public List<string> ToInstall { get; set; } = [];
+
+    /// <summary>Unsupported extensions that will be skipped.</summary>
+    public List<string> Skipped { get; set; } = [];
+
+    /// <summary>Warnings generated during evaluation.</summary>
+    public List<ExtensionWarning> Warnings { get; set; } = [];
+}
+
+/// <summary>
+/// Result of installing PostgreSQL extensions on an Azure target.
+/// </summary>
+public class ExtensionMigrationResult
+{
+    /// <summary>Extensions successfully installed.</summary>
+    public List<string> Installed { get; set; } = [];
+
+    /// <summary>Extensions skipped (unsupported).</summary>
+    public List<string> Skipped { get; set; } = [];
+
+    /// <summary>Extensions that failed to install.</summary>
+    public List<string> Failed { get; set; } = [];
+
+    /// <summary>Warnings generated during installation.</summary>
+    public List<ExtensionWarning> Warnings { get; set; } = [];
+
+    /// <summary>True if no extensions failed to install.</summary>
+    public bool Success => Failed.Count == 0;
+}
+
+/// <summary>
+/// Warning about an extension during migration evaluation or installation.
+/// </summary>
+public class ExtensionWarning
+{
+    public string ExtensionName { get; set; } = string.Empty;
+    public string Message { get; set; } = string.Empty;
+    public ExtensionWarningSeverity Severity { get; set; }
+}
+
+/// <summary>
+/// Severity level for extension warnings.
+/// </summary>
+public enum ExtensionWarningSeverity
+{
+    Info,
+    Warning,
+    Error
+}

--- a/src/Scaffold.Migration/PostgreSql/Models/PgSchemaSnapshot.cs
+++ b/src/Scaffold.Migration/PostgreSql/Models/PgSchemaSnapshot.cs
@@ -1,0 +1,15 @@
+namespace Scaffold.Migration.PostgreSql.Models;
+
+/// <summary>
+/// Snapshot of a PostgreSQL database schema, extracted from pg_catalog and information_schema.
+/// Contains all objects needed to recreate the schema on a target database.
+/// </summary>
+public class PgSchemaSnapshot
+{
+    public List<PgTableDefinition> Tables { get; set; } = [];
+    public List<PgViewDefinition> Views { get; set; } = [];
+    public List<PgFunctionDefinition> Functions { get; set; } = [];
+    public List<PgSequenceDefinition> Sequences { get; set; } = [];
+    public List<PgEnumTypeDefinition> EnumTypes { get; set; } = [];
+    public List<string> Extensions { get; set; } = [];
+}

--- a/src/Scaffold.Migration/PostgreSql/Models/PgTableDefinition.cs
+++ b/src/Scaffold.Migration/PostgreSql/Models/PgTableDefinition.cs
@@ -1,0 +1,139 @@
+namespace Scaffold.Migration.PostgreSql.Models;
+
+/// <summary>
+/// PostgreSQL-native table definition with PG-specific schema metadata.
+/// Used by the PG→PG migration path (schema extractor, DDL generator, bulk copier).
+/// Unlike the SQL Server-oriented <see cref="TableDefinition"/>, this uses PG-native
+/// naming and concepts (schemas default to "public", identity uses GENERATED, etc.).
+/// </summary>
+public class PgTableDefinition
+{
+    public string Schema { get; set; } = "public";
+    public string TableName { get; set; } = string.Empty;
+    public List<PgColumnDefinition> Columns { get; set; } = [];
+    public PgPrimaryKeyDefinition? PrimaryKey { get; set; }
+    public List<PgIndexDefinition> Indexes { get; set; } = [];
+    public List<PgForeignKeyDefinition> ForeignKeys { get; set; } = [];
+    public List<PgCheckConstraintDefinition> CheckConstraints { get; set; } = [];
+    public List<PgUniqueConstraintDefinition> UniqueConstraints { get; set; } = [];
+    public List<PgSequenceDefinition> OwnedSequences { get; set; } = [];
+
+    /// <summary>Fully qualified name: schema.table</summary>
+    public string QualifiedName => $"{Schema}.{TableName}";
+}
+
+public class PgColumnDefinition
+{
+    public string Name { get; set; } = string.Empty;
+    /// <summary>PostgreSQL data type (e.g., "integer", "text", "timestamp with time zone").</summary>
+    public string DataType { get; set; } = string.Empty;
+    /// <summary>Full type with modifiers (e.g., "character varying(255)").</summary>
+    public string FullType { get; set; } = string.Empty;
+    public int? MaxLength { get; set; }
+    public int? Precision { get; set; }
+    public int? Scale { get; set; }
+    public bool IsNullable { get; set; }
+    public bool IsIdentity { get; set; }
+    /// <summary>"ALWAYS" or "BY DEFAULT"</summary>
+    public string? IdentityGeneration { get; set; }
+    /// <summary>PG default expression (e.g., "now()", "'active'::text").</summary>
+    public string? DefaultExpression { get; set; }
+    public bool IsGenerated { get; set; }
+    /// <summary>Expression for GENERATED ALWAYS AS (stored) columns.</summary>
+    public string? GenerationExpression { get; set; }
+    public int OrdinalPosition { get; set; }
+    public string? Collation { get; set; }
+    /// <summary>For enum/composite/domain types, the UDT name.</summary>
+    public string? UdtName { get; set; }
+}
+
+public class PgPrimaryKeyDefinition
+{
+    public string Name { get; set; } = string.Empty;
+    public List<string> Columns { get; set; } = [];
+}
+
+public class PgForeignKeyDefinition
+{
+    public string Name { get; set; } = string.Empty;
+    public string ReferencedSchema { get; set; } = "public";
+    public string ReferencedTable { get; set; } = string.Empty;
+    public List<string> Columns { get; set; } = [];
+    public List<string> ReferencedColumns { get; set; } = [];
+    public string DeleteAction { get; set; } = "NO ACTION";
+    public string UpdateAction { get; set; } = "NO ACTION";
+}
+
+public class PgIndexDefinition
+{
+    public string Name { get; set; } = string.Empty;
+    public List<string> Columns { get; set; } = [];
+    public List<string> IncludedColumns { get; set; } = [];
+    public bool IsUnique { get; set; }
+    /// <summary>PG index method: btree, hash, gin, gist, etc.</summary>
+    public string AccessMethod { get; set; } = "btree";
+    public string? FilterExpression { get; set; }
+    /// <summary>Raw CREATE INDEX DDL for complex indexes that can't be decomposed.</summary>
+    public string? RawDdl { get; set; }
+}
+
+public class PgCheckConstraintDefinition
+{
+    public string Name { get; set; } = string.Empty;
+    public string Expression { get; set; } = string.Empty;
+}
+
+public class PgUniqueConstraintDefinition
+{
+    public string Name { get; set; } = string.Empty;
+    public List<string> Columns { get; set; } = [];
+}
+
+public class PgSequenceDefinition
+{
+    public string Schema { get; set; } = "public";
+    public string Name { get; set; } = string.Empty;
+    public string DataType { get; set; } = "bigint";
+    public long StartValue { get; set; } = 1;
+    public long IncrementBy { get; set; } = 1;
+    public long? MinValue { get; set; }
+    public long? MaxValue { get; set; }
+    public bool IsCyclic { get; set; }
+    /// <summary>Table.Column this sequence is owned by (e.g., "users.id").</summary>
+    public string? OwnedBy { get; set; }
+}
+
+/// <summary>
+/// Represents a PostgreSQL view definition.
+/// </summary>
+public class PgViewDefinition
+{
+    public string Schema { get; set; } = "public";
+    public string Name { get; set; } = string.Empty;
+    /// <summary>Raw view DDL (CREATE OR REPLACE VIEW ...).</summary>
+    public string Definition { get; set; } = string.Empty;
+    public bool IsMaterialized { get; set; }
+}
+
+/// <summary>
+/// Represents a PostgreSQL function/procedure definition.
+/// </summary>
+public class PgFunctionDefinition
+{
+    public string Schema { get; set; } = "public";
+    public string Name { get; set; } = string.Empty;
+    /// <summary>Raw function DDL (CREATE OR REPLACE FUNCTION ...).</summary>
+    public string Definition { get; set; } = string.Empty;
+    public string Language { get; set; } = "plpgsql";
+    public string Kind { get; set; } = "f"; // f=function, p=procedure
+}
+
+/// <summary>
+/// Represents a PostgreSQL custom enum type.
+/// </summary>
+public class PgEnumTypeDefinition
+{
+    public string Schema { get; set; } = "public";
+    public string Name { get; set; } = string.Empty;
+    public List<string> Labels { get; set; } = [];
+}

--- a/src/Scaffold.Migration/PostgreSql/Models/PgTableDefinition.cs
+++ b/src/Scaffold.Migration/PostgreSql/Models/PgTableDefinition.cs
@@ -45,6 +45,8 @@ public class PgColumnDefinition
     public string? Collation { get; set; }
     /// <summary>For enum/composite/domain types, the UDT name.</summary>
     public string? UdtName { get; set; }
+    /// <summary>Schema of the UDT (for USER-DEFINED types).</summary>
+    public string? UdtSchema { get; set; }
 }
 
 public class PgPrimaryKeyDefinition

--- a/src/Scaffold.Migration/PostgreSql/PgIdentifierHelper.cs
+++ b/src/Scaffold.Migration/PostgreSql/PgIdentifierHelper.cs
@@ -1,0 +1,62 @@
+namespace Scaffold.Migration.PostgreSql;
+
+/// <summary>
+/// Shared PostgreSQL identifier quoting and schema mapping utilities.
+/// Consolidates duplicate logic from DdlTranslator, CrossPlatformBulkCopier,
+/// and PostgreSqlValidationEngine.
+/// </summary>
+public static class PgIdentifierHelper
+{
+    /// <summary>
+    /// Wraps an identifier in PostgreSQL double-quotes, escaping embedded quotes.
+    /// </summary>
+    public static string QuoteIdentifier(string name) => $"\"{name.Replace("\"", "\"\"")}\"";
+
+    /// <summary>
+    /// Maps SQL Server schema names to PostgreSQL equivalents.
+    /// "dbo" → "public"; all others preserved.
+    /// </summary>
+    public static string MapSchema(string schema)
+        => schema.Equals("dbo", StringComparison.OrdinalIgnoreCase) ? "public" : schema;
+
+    /// <summary>
+    /// Quotes a dotted table name for PostgreSQL: dbo.Users → "public"."Users".
+    /// Maps "dbo" schema to "public". Escapes embedded double-quotes.
+    /// Strips SQL Server bracket notation [name] and existing PG quotes.
+    /// </summary>
+    public static string QuotePgName(string tableName)
+    {
+        var parts = tableName.Split('.');
+        if (parts.Length == 2 &&
+            parts[0].Trim('[', ']', '"').Equals("dbo", StringComparison.OrdinalIgnoreCase))
+        {
+            parts[0] = "public";
+        }
+
+        return string.Join(".", parts.Select(p =>
+        {
+            var clean = p.Trim('[', ']', '"');
+            return $"\"{clean.Replace("\"", "\"\"")}\"";
+        }));
+    }
+
+    /// <summary>
+    /// Quotes a dotted table name for SQL Server: dbo.Users → [dbo].[Users].
+    /// Escapes embedded ']' characters by doubling them.
+    /// </summary>
+    public static string QuoteSqlName(string tableName)
+    {
+        var parts = tableName.Split('.');
+        return string.Join(".", parts.Select(p =>
+        {
+            var clean = p.Trim('[', ']');
+            return $"[{clean.Replace("]", "]]")}]";
+        }));
+    }
+
+    /// <summary>
+    /// Clamps a timeout value to [30, 3600], using defaultValue when value is null.
+    /// </summary>
+    public static int ClampTimeout(int? value, int defaultValue)
+        => Math.Clamp(value ?? defaultValue, 30, 3600);
+}

--- a/src/Scaffold.Migration/PostgreSql/PostgreSqlBulkCopier.cs
+++ b/src/Scaffold.Migration/PostgreSql/PostgreSqlBulkCopier.cs
@@ -1,0 +1,354 @@
+using Npgsql;
+using Scaffold.Core.Interfaces;
+using Scaffold.Migration.Shared;
+
+namespace Scaffold.Migration.PostgreSql;
+
+/// <summary>
+/// Copies data between PostgreSQL databases using the COPY protocol.
+/// Streams data without loading entire tables into memory.
+/// Tables are processed in FK dependency order.
+/// </summary>
+public class PostgreSqlBulkCopier
+{
+    private const int DefaultTimeoutSeconds = 600;
+    private const int ProgressReportInterval = 10_000;
+
+    /// <summary>
+    /// Copies all rows for specified tables from source PG to target PG.
+    /// Tables are ordered by FK dependencies (parents before children).
+    /// </summary>
+    /// <param name="sourceConnectionString">PostgreSQL source connection string.</param>
+    /// <param name="targetConnectionString">PostgreSQL target connection string.</param>
+    /// <param name="tableNames">Tables to copy (schema.table format).</param>
+    /// <param name="progress">Optional progress reporter.</param>
+    /// <param name="bulkCopyTimeout">Optional timeout in seconds (clamped to 30-3600).</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Total rows copied across all tables.</returns>
+    public virtual async Task<long> CopyDataAsync(
+        string sourceConnectionString,
+        string targetConnectionString,
+        IReadOnlyList<string> tableNames,
+        IProgress<MigrationProgress>? progress = null,
+        int? bulkCopyTimeout = null,
+        CancellationToken ct = default)
+    {
+        var timeout = PgIdentifierHelper.ClampTimeout(bulkCopyTimeout, DefaultTimeoutSeconds);
+
+        var orderedTables = tableNames.Count > 0
+            ? await GetOrderedTablesAsync(sourceConnectionString, tableNames, ct)
+            : [];
+
+        if (orderedTables.Count == 0)
+        {
+            progress?.Report(new MigrationProgress
+            {
+                Phase = "DataMigration",
+                PercentComplete = 100,
+                Message = "No tables to migrate."
+            });
+            return 0;
+        }
+
+        long totalRows = 0;
+        for (int i = 0; i < orderedTables.Count; i++)
+        {
+            ct.ThrowIfCancellationRequested();
+            var table = orderedTables[i];
+
+            progress?.Report(new MigrationProgress
+            {
+                Phase = "DataMigration",
+                PercentComplete = (double)i / orderedTables.Count * 100,
+                CurrentTable = table,
+                Message = $"Copying table {i + 1}/{orderedTables.Count}: {table}..."
+            });
+
+            var rowsCopied = await CopyTableAsync(
+                sourceConnectionString, targetConnectionString,
+                table, timeout, i, orderedTables.Count, progress, ct);
+            totalRows += rowsCopied;
+        }
+
+        progress?.Report(new MigrationProgress
+        {
+            Phase = "DataMigration",
+            PercentComplete = 100,
+            RowsProcessed = totalRows,
+            Message = $"Data migration complete: {totalRows:N0} rows copied across {orderedTables.Count} tables."
+        });
+
+        return totalRows;
+    }
+
+    /// <summary>
+    /// Resets sequences on the target to match the max values after data copy.
+    /// Should be called after all tables have been copied.
+    /// </summary>
+    /// <param name="targetConnectionString">PostgreSQL target connection string.</param>
+    /// <param name="ct">Cancellation token.</param>
+    public virtual async Task ResetSequencesAsync(
+        string targetConnectionString,
+        CancellationToken ct = default)
+    {
+        await using var conn = new NpgsqlConnection(targetConnectionString);
+        await conn.OpenAsync(ct);
+
+        // Find all sequences owned by table columns (identity/serial columns)
+        await using var cmd = new NpgsqlCommand(@"
+            SELECT n.nspname || '.' || s.relname as seq_name,
+                   dep_n.nspname || '.' || dep_t.relname as table_name,
+                   a.attname as column_name
+            FROM pg_class s
+            JOIN pg_namespace n ON s.relnamespace = n.oid
+            JOIN pg_depend d ON d.objid = s.oid AND d.deptype = 'a'
+            JOIN pg_class dep_t ON d.refobjid = dep_t.oid
+            JOIN pg_namespace dep_n ON dep_t.relnamespace = dep_n.oid
+            JOIN pg_attribute a ON a.attrelid = d.refobjid AND a.attnum = d.refobjsubid
+            WHERE s.relkind = 'S'
+              AND n.nspname NOT IN ('pg_catalog', 'information_schema')", conn);
+
+        var sequences = new List<(string SeqName, string TableName, string ColumnName)>();
+        await using (var reader = await cmd.ExecuteReaderAsync(ct))
+        {
+            while (await reader.ReadAsync(ct))
+            {
+                sequences.Add((reader.GetString(0), reader.GetString(1), reader.GetString(2)));
+            }
+        }
+
+        foreach (var (seqName, tableName, columnName) in sequences)
+        {
+            ct.ThrowIfCancellationRequested();
+            var quotedTable = PgIdentifierHelper.QuotePgName(tableName);
+            var quotedCol = PgIdentifierHelper.QuoteIdentifier(columnName);
+            var quotedSeq = PgIdentifierHelper.QuotePgName(seqName);
+
+            // setval to max value, or 1 if table is empty
+            await using var setCmd = new NpgsqlCommand(
+                $"SELECT setval({quotedSeq}::text::regclass, COALESCE((SELECT MAX({quotedCol}) FROM {quotedTable}), 1), true)",
+                conn);
+            await setCmd.ExecuteNonQueryAsync(ct);
+        }
+    }
+
+    /// <summary>
+    /// Copies a single table from source PG to target PG using text-mode COPY protocol.
+    /// Disables triggers during import and re-enables them after.
+    /// Truncates the target table before copying for re-runnable migrations.
+    /// </summary>
+    internal virtual async Task<long> CopyTableAsync(
+        string sourceConnectionString,
+        string targetConnectionString,
+        string tableName,
+        int timeout,
+        int tableIndex,
+        int tableCount,
+        IProgress<MigrationProgress>? progress,
+        CancellationToken ct)
+    {
+        var pgTableName = PgIdentifierHelper.QuotePgName(tableName);
+        long rowCount = 0;
+
+        // Get column names from source to build matching COPY commands
+        var columnNames = await GetColumnNamesAsync(sourceConnectionString, tableName, ct);
+        var pgColumns = string.Join(", ", columnNames.Select(PgIdentifierHelper.QuoteIdentifier));
+
+        // Use text mode COPY (safe across PG versions)
+        var exportCmd = $"COPY {pgTableName} ({pgColumns}) TO STDOUT";
+        var importCmd = $"COPY {pgTableName} ({pgColumns}) FROM STDIN";
+
+        await using var targetConn = new NpgsqlConnection(targetConnectionString);
+        await targetConn.OpenAsync(ct);
+        await using var transaction = await targetConn.BeginTransactionAsync(ct);
+
+        try
+        {
+            // Disable triggers to avoid FK violations during bulk load
+            await using (var disableCmd = new NpgsqlCommand(
+                $"ALTER TABLE {pgTableName} DISABLE TRIGGER ALL", targetConn, transaction))
+            {
+                disableCmd.CommandTimeout = timeout;
+                await disableCmd.ExecuteNonQueryAsync(ct);
+            }
+
+            // TRUNCATE target table (for re-runnable migrations)
+            await using (var truncCmd = new NpgsqlCommand(
+                $"TRUNCATE TABLE {pgTableName} CASCADE", targetConn, transaction))
+            {
+                truncCmd.CommandTimeout = timeout;
+                await truncCmd.ExecuteNonQueryAsync(ct);
+            }
+
+            // Stream data: source COPY TO → target COPY FROM
+            await using var sourceConn = new NpgsqlConnection(sourceConnectionString);
+            await sourceConn.OpenAsync(ct);
+
+            // Scope the reader/writer so they are disposed before ENABLE TRIGGER ALL;
+            // Npgsql keeps the connection in COPY state until the reader/writer is disposed.
+            // TextReader/TextWriter don't implement IAsyncDisposable, so use synchronous using.
+            using (var exportReader = await sourceConn.BeginTextExportAsync(exportCmd, ct))
+            await using (var importWriter = await targetConn.BeginTextImportAsync(importCmd, ct))
+            {
+                // Stream character data in chunks
+                var buffer = new char[65536];
+                int charsRead;
+                while ((charsRead = await exportReader.ReadAsync(buffer, 0, buffer.Length)) > 0)
+                {
+                    ct.ThrowIfCancellationRequested();
+                    await importWriter.WriteAsync(buffer, 0, charsRead);
+
+                    // Estimate rows from newlines for progress reporting
+                    for (int i = 0; i < charsRead; i++)
+                    {
+                        if (buffer[i] == '\n') rowCount++;
+                    }
+
+                    if (rowCount % ProgressReportInterval < 100)
+                    {
+                        var pct = (double)tableIndex / tableCount * 100 + (1.0 / tableCount * 50);
+                        progress?.Report(new MigrationProgress
+                        {
+                            Phase = "DataMigration",
+                            PercentComplete = pct,
+                            CurrentTable = tableName,
+                            RowsProcessed = rowCount,
+                            Message = $"Copying {tableName}: {rowCount:N0} rows so far..."
+                        });
+                    }
+                }
+            }
+
+            // Re-enable triggers within the same transaction
+            await using (var enableCmd = new NpgsqlCommand(
+                $"ALTER TABLE {pgTableName} ENABLE TRIGGER ALL", targetConn, transaction))
+            {
+                enableCmd.CommandTimeout = timeout;
+                await enableCmd.ExecuteNonQueryAsync(ct);
+            }
+
+            await transaction.CommitAsync(ct);
+        }
+        catch
+        {
+            await transaction.RollbackAsync(ct);
+            throw;
+        }
+
+        return rowCount;
+    }
+
+    /// <summary>
+    /// Gets column names for a table from the source PG database.
+    /// Excludes generated columns (PG won't allow writing to them via COPY).
+    /// </summary>
+    internal static async Task<List<string>> GetColumnNamesAsync(
+        string connectionString, string tableName, CancellationToken ct)
+    {
+        await using var conn = new NpgsqlConnection(connectionString);
+        await conn.OpenAsync(ct);
+
+        var parts = tableName.Split('.');
+        var schema = parts.Length == 2 ? parts[0].Trim('"', '[', ']') : "public";
+        var table = parts.Length == 2 ? parts[1].Trim('"', '[', ']') : parts[0].Trim('"', '[', ']');
+
+        await using var cmd = new NpgsqlCommand(@"
+            SELECT column_name
+            FROM information_schema.columns
+            WHERE table_schema = @schema AND table_name = @table
+              AND is_generated = 'NEVER'
+              AND (generation_expression IS NULL OR generation_expression = '')
+            ORDER BY ordinal_position", conn);
+        cmd.Parameters.AddWithValue("schema", schema);
+        cmd.Parameters.AddWithValue("table", table);
+
+        var columns = new List<string>();
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+        while (await reader.ReadAsync(ct))
+        {
+            columns.Add(reader.GetString(0));
+        }
+
+        return columns;
+    }
+
+    /// <summary>
+    /// Gets tables ordered by FK dependencies (parents first) from the PG source.
+    /// Uses pg_constraint to discover foreign key relationships, then applies
+    /// topological sort via Kahn's algorithm.
+    /// </summary>
+    internal virtual async Task<List<string>> GetOrderedTablesAsync(
+        string connectionString,
+        IReadOnlyList<string> tableNames,
+        CancellationToken ct)
+    {
+        await using var conn = new NpgsqlConnection(connectionString);
+        await conn.OpenAsync(ct);
+
+        // Build lookup of all FK dependencies from pg_constraint
+        var dependsOn = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var t in tableNames)
+            dependsOn[t] = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        await using var cmd = new NpgsqlCommand(@"
+            SELECT
+                cn.nspname || '.' || c.relname as child_table,
+                pn.nspname || '.' || p.relname as parent_table
+            FROM pg_constraint con
+            JOIN pg_class c ON con.conrelid = c.oid
+            JOIN pg_namespace cn ON c.relnamespace = cn.oid
+            JOIN pg_class p ON con.confrelid = p.oid
+            JOIN pg_namespace pn ON p.relnamespace = pn.oid
+            WHERE con.contype = 'f'
+              AND cn.nspname NOT IN ('pg_catalog', 'information_schema')", conn);
+
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+        while (await reader.ReadAsync(ct))
+        {
+            var child = reader.GetString(0);
+            var parent = reader.GetString(1);
+
+            if (dependsOn.ContainsKey(child) && dependsOn.ContainsKey(parent)
+                && !string.Equals(child, parent, StringComparison.OrdinalIgnoreCase))
+            {
+                dependsOn[child].Add(parent);
+            }
+        }
+
+        return TopologicalSorter.Sort(tableNames.ToList(), dependsOn);
+    }
+
+    /// <summary>
+    /// Builds the COPY export command for a table with quoted column names.
+    /// Exposed for testing.
+    /// </summary>
+    internal static string BuildCopyExportCommand(string tableName, IReadOnlyList<string> columnNames)
+    {
+        var pgTableName = PgIdentifierHelper.QuotePgName(tableName);
+        var pgColumns = string.Join(", ", columnNames.Select(PgIdentifierHelper.QuoteIdentifier));
+        return $"COPY {pgTableName} ({pgColumns}) TO STDOUT";
+    }
+
+    /// <summary>
+    /// Builds the COPY import command for a table with quoted column names.
+    /// Exposed for testing.
+    /// </summary>
+    internal static string BuildCopyImportCommand(string tableName, IReadOnlyList<string> columnNames)
+    {
+        var pgTableName = PgIdentifierHelper.QuotePgName(tableName);
+        var pgColumns = string.Join(", ", columnNames.Select(PgIdentifierHelper.QuoteIdentifier));
+        return $"COPY {pgTableName} ({pgColumns}) FROM STDIN";
+    }
+
+    /// <summary>
+    /// Builds the SQL command to reset a sequence to the max value of its owning column.
+    /// Exposed for testing.
+    /// </summary>
+    internal static string BuildResetSequenceSql(string seqName, string tableName, string columnName)
+    {
+        var quotedTable = PgIdentifierHelper.QuotePgName(tableName);
+        var quotedCol = PgIdentifierHelper.QuoteIdentifier(columnName);
+        var quotedSeq = PgIdentifierHelper.QuotePgName(seqName);
+        return $"SELECT setval({quotedSeq}::text::regclass, COALESCE((SELECT MAX({quotedCol}) FROM {quotedTable}), 1), true)";
+    }
+}

--- a/src/Scaffold.Migration/PostgreSql/PostgreSqlBulkCopier.cs
+++ b/src/Scaffold.Migration/PostgreSql/PostgreSqlBulkCopier.cs
@@ -122,12 +122,13 @@ public class PostgreSqlBulkCopier
             ct.ThrowIfCancellationRequested();
             var quotedTable = PgIdentifierHelper.QuotePgName(tableName);
             var quotedCol = PgIdentifierHelper.QuoteIdentifier(columnName);
-            var quotedSeq = PgIdentifierHelper.QuotePgName(seqName);
 
-            // setval to max value, or 1 if table is empty
+            // Use parameterized query with regclass cast for safe sequence resolution.
+            // is_called is conditional: false when table is empty (so next nextval returns 1).
             await using var setCmd = new NpgsqlCommand(
-                $"SELECT setval({quotedSeq}::text::regclass, COALESCE((SELECT MAX({quotedCol}) FROM {quotedTable}), 1), true)",
+                $"SELECT setval(@seqName::regclass, COALESCE((SELECT MAX({quotedCol}) FROM {quotedTable}), 1), COALESCE((SELECT MAX({quotedCol}) FROM {quotedTable}) IS NOT NULL, false))",
                 conn);
+            setCmd.Parameters.AddWithValue("seqName", seqName);
             await setCmd.ExecuteNonQueryAsync(ct);
         }
     }
@@ -342,13 +343,16 @@ public class PostgreSqlBulkCopier
 
     /// <summary>
     /// Builds the SQL command to reset a sequence to the max value of its owning column.
+    /// Uses single-quoted literal with regclass cast for safe sequence resolution.
+    /// The is_called parameter is conditional: false when the table is empty so
+    /// the next nextval() returns 1 (not 2).
     /// Exposed for testing.
     /// </summary>
     internal static string BuildResetSequenceSql(string seqName, string tableName, string columnName)
     {
         var quotedTable = PgIdentifierHelper.QuotePgName(tableName);
         var quotedCol = PgIdentifierHelper.QuoteIdentifier(columnName);
-        var quotedSeq = PgIdentifierHelper.QuotePgName(seqName);
-        return $"SELECT setval({quotedSeq}::text::regclass, COALESCE((SELECT MAX({quotedCol}) FROM {quotedTable}), 1), true)";
+        var escapedSeq = seqName.Replace("'", "''");
+        return $"SELECT setval('{escapedSeq}'::regclass, COALESCE((SELECT MAX({quotedCol}) FROM {quotedTable}), 1), COALESCE((SELECT MAX({quotedCol}) FROM {quotedTable}) IS NOT NULL, false))";
     }
 }

--- a/src/Scaffold.Migration/PostgreSql/PostgreSqlDdlGenerator.cs
+++ b/src/Scaffold.Migration/PostgreSql/PostgreSqlDdlGenerator.cs
@@ -1,0 +1,284 @@
+using System.Text;
+using Scaffold.Migration.PostgreSql.Models;
+using Scaffold.Migration.Shared;
+
+namespace Scaffold.Migration.PostgreSql;
+
+/// <summary>
+/// Generates DDL from PG-native models to deploy on a PostgreSQL target.
+/// Produces statements in dependency order: enum types → sequences → tables (topological)
+/// → foreign keys → indexes → views → functions.
+/// </summary>
+public class PostgreSqlDdlGenerator
+{
+    /// <summary>
+    /// Generates all DDL statements from a PG schema snapshot, in dependency order.
+    /// </summary>
+    public virtual List<string> GenerateDdl(PgSchemaSnapshot schema)
+    {
+        var ddl = new List<string>();
+
+        // 1. Enum types (must exist before tables that reference them)
+        foreach (var enumType in schema.EnumTypes)
+        {
+            ddl.Add(GenerateCreateEnum(enumType));
+        }
+
+        // 2. Sequences (must exist before tables with default nextval())
+        foreach (var sequence in schema.Sequences)
+        {
+            ddl.Add(GenerateCreateSequence(sequence));
+        }
+
+        // 3. Tables in topological order (parents before children)
+        var orderedTables = TopologicalSorter.Sort(
+            schema.Tables,
+            t => t.QualifiedName,
+            t => t.ForeignKeys.Select(fk => $"{fk.ReferencedSchema}.{fk.ReferencedTable}"));
+
+        foreach (var table in orderedTables)
+        {
+            ddl.Add(GenerateCreateTable(table));
+        }
+
+        // 4. Foreign keys (after all tables exist)
+        foreach (var table in orderedTables)
+        {
+            foreach (var fk in table.ForeignKeys)
+            {
+                ddl.Add(GenerateAddForeignKey(table, fk));
+            }
+        }
+
+        // 5. Indexes
+        foreach (var table in orderedTables)
+        {
+            foreach (var index in table.Indexes)
+            {
+                ddl.Add(GenerateCreateIndex(table, index));
+            }
+        }
+
+        // 6. Views
+        foreach (var view in schema.Views)
+        {
+            ddl.Add(GenerateCreateView(view));
+        }
+
+        // 7. Functions
+        foreach (var function in schema.Functions)
+        {
+            ddl.Add(GenerateCreateFunction(function));
+        }
+
+        return ddl;
+    }
+
+    internal string GenerateCreateEnum(PgEnumTypeDefinition enumType)
+    {
+        var labels = string.Join(", ", enumType.Labels.Select(l => $"'{l.Replace("'", "''")}'"));
+        return $"CREATE TYPE {Quote(enumType.Schema)}.{Quote(enumType.Name)} AS ENUM ({labels});";
+    }
+
+    internal string GenerateCreateSequence(PgSequenceDefinition sequence)
+    {
+        var sb = new StringBuilder();
+        sb.Append($"CREATE SEQUENCE {Quote(sequence.Schema)}.{Quote(sequence.Name)}");
+        sb.Append($" AS {sequence.DataType}");
+        sb.Append($" START WITH {sequence.StartValue}");
+        sb.Append($" INCREMENT BY {sequence.IncrementBy}");
+
+        if (sequence.MinValue.HasValue)
+            sb.Append($" MINVALUE {sequence.MinValue.Value}");
+        else
+            sb.Append(" NO MINVALUE");
+
+        if (sequence.MaxValue.HasValue)
+            sb.Append($" MAXVALUE {sequence.MaxValue.Value}");
+        else
+            sb.Append(" NO MAXVALUE");
+
+        sb.Append(sequence.IsCyclic ? " CYCLE" : " NO CYCLE");
+
+        if (!string.IsNullOrEmpty(sequence.OwnedBy))
+        {
+            // OwnedBy is "schema.table.column" — need to quote each part
+            var parts = sequence.OwnedBy.Split('.');
+            if (parts.Length == 3)
+            {
+                sb.Append($" OWNED BY {Quote(parts[0])}.{Quote(parts[1])}.{Quote(parts[2])}");
+            }
+            else
+            {
+                // Fallback: quote the whole thing
+                sb.Append($" OWNED BY {sequence.OwnedBy}");
+            }
+        }
+
+        sb.Append(';');
+        return sb.ToString();
+    }
+
+    internal string GenerateCreateTable(PgTableDefinition table)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"CREATE TABLE {Quote(table.Schema)}.{Quote(table.TableName)} (");
+
+        var parts = new List<string>();
+
+        foreach (var col in table.Columns.OrderBy(c => c.OrdinalPosition))
+        {
+            parts.Add(GenerateColumnDefinition(col));
+        }
+
+        // Primary key constraint
+        if (table.PrimaryKey is { Columns.Count: > 0 })
+        {
+            var pkCols = string.Join(", ", table.PrimaryKey.Columns.Select(Quote));
+            parts.Add($"    CONSTRAINT {Quote(table.PrimaryKey.Name)} PRIMARY KEY ({pkCols})");
+        }
+
+        // Unique constraints
+        foreach (var uq in table.UniqueConstraints)
+        {
+            var uqCols = string.Join(", ", uq.Columns.Select(Quote));
+            parts.Add($"    CONSTRAINT {Quote(uq.Name)} UNIQUE ({uqCols})");
+        }
+
+        // Check constraints
+        foreach (var chk in table.CheckConstraints)
+        {
+            parts.Add($"    CONSTRAINT {Quote(chk.Name)} CHECK ({chk.Expression})");
+        }
+
+        sb.AppendLine(string.Join(",\n", parts));
+        sb.Append(");");
+
+        return sb.ToString();
+    }
+
+    private static string GenerateColumnDefinition(PgColumnDefinition col)
+    {
+        var sb = new StringBuilder();
+        sb.Append($"    {Quote(col.Name)} ");
+
+        if (col.IsIdentity)
+        {
+            // Use GENERATED ... AS IDENTITY
+            sb.Append(col.FullType);
+            sb.Append($" GENERATED {col.IdentityGeneration ?? "BY DEFAULT"} AS IDENTITY");
+        }
+        else if (col.IsGenerated && !string.IsNullOrEmpty(col.GenerationExpression))
+        {
+            sb.Append(col.FullType);
+            sb.Append($" GENERATED ALWAYS AS ({col.GenerationExpression}) STORED");
+        }
+        else
+        {
+            sb.Append(col.FullType);
+
+            if (col.DefaultExpression != null)
+            {
+                sb.Append($" DEFAULT {col.DefaultExpression}");
+            }
+        }
+
+        if (!col.IsNullable)
+        {
+            sb.Append(" NOT NULL");
+        }
+
+        if (!string.IsNullOrEmpty(col.Collation))
+        {
+            sb.Append($" COLLATE {Quote(col.Collation)}");
+        }
+
+        return sb.ToString();
+    }
+
+    internal string GenerateAddForeignKey(PgTableDefinition table, PgForeignKeyDefinition fk)
+    {
+        var fkCols = string.Join(", ", fk.Columns.Select(Quote));
+        var refCols = string.Join(", ", fk.ReferencedColumns.Select(Quote));
+
+        var sb = new StringBuilder();
+        sb.Append($"ALTER TABLE {Quote(table.Schema)}.{Quote(table.TableName)} ");
+        sb.AppendLine($"ADD CONSTRAINT {Quote(fk.Name)}");
+        sb.Append($"    FOREIGN KEY ({fkCols}) REFERENCES {Quote(fk.ReferencedSchema)}.{Quote(fk.ReferencedTable)} ({refCols})");
+        sb.Append($" ON DELETE {ValidateReferentialAction(fk.DeleteAction)} ON UPDATE {ValidateReferentialAction(fk.UpdateAction)};");
+
+        return sb.ToString();
+    }
+
+    internal string GenerateCreateIndex(PgTableDefinition table, PgIndexDefinition index)
+    {
+        // If raw DDL is available and appears to be a complete statement, use it directly
+        if (!string.IsNullOrWhiteSpace(index.RawDdl) &&
+            index.RawDdl.StartsWith("CREATE", StringComparison.OrdinalIgnoreCase))
+        {
+            var rawDdl = index.RawDdl.TrimEnd();
+            return rawDdl.EndsWith(';') ? rawDdl : rawDdl + ";";
+        }
+
+        // Construct from parts
+        var sb = new StringBuilder();
+        sb.Append("CREATE ");
+        if (index.IsUnique) sb.Append("UNIQUE ");
+        sb.Append($"INDEX {Quote(index.Name)} ON {Quote(table.Schema)}.{Quote(table.TableName)}");
+
+        if (!string.Equals(index.AccessMethod, "btree", StringComparison.OrdinalIgnoreCase))
+        {
+            sb.Append($" USING {index.AccessMethod}");
+        }
+
+        var keyCols = string.Join(", ", index.Columns.Select(Quote));
+        sb.Append($" ({keyCols})");
+
+        if (index.IncludedColumns.Count > 0)
+        {
+            var inclCols = string.Join(", ", index.IncludedColumns.Select(Quote));
+            sb.Append($" INCLUDE ({inclCols})");
+        }
+
+        if (!string.IsNullOrWhiteSpace(index.FilterExpression))
+        {
+            sb.Append($" WHERE {index.FilterExpression}");
+        }
+
+        sb.Append(';');
+        return sb.ToString();
+    }
+
+    internal string GenerateCreateView(PgViewDefinition view)
+    {
+        var definition = view.Definition.TrimEnd().TrimEnd(';');
+
+        if (view.IsMaterialized)
+        {
+            return $"CREATE MATERIALIZED VIEW {Quote(view.Schema)}.{Quote(view.Name)} AS {definition};";
+        }
+
+        return $"CREATE OR REPLACE VIEW {Quote(view.Schema)}.{Quote(view.Name)} AS {definition};";
+    }
+
+    internal string GenerateCreateFunction(PgFunctionDefinition function)
+    {
+        // pg_get_functiondef already includes the full CREATE OR REPLACE FUNCTION statement
+        var definition = function.Definition.TrimEnd();
+        return definition.EndsWith(';') ? definition : definition + ";";
+    }
+
+    private static string Quote(string name) => PgIdentifierHelper.QuoteIdentifier(name);
+
+    private static readonly HashSet<string> ValidReferentialActions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "NO ACTION", "CASCADE", "SET NULL", "SET DEFAULT", "RESTRICT"
+    };
+
+    private static string ValidateReferentialAction(string action)
+    {
+        if (ValidReferentialActions.Contains(action))
+            return action.ToUpperInvariant();
+        return "NO ACTION";
+    }
+}

--- a/src/Scaffold.Migration/PostgreSql/PostgreSqlMigrator.cs
+++ b/src/Scaffold.Migration/PostgreSql/PostgreSqlMigrator.cs
@@ -1,0 +1,249 @@
+using Npgsql;
+using Scaffold.Core.Interfaces;
+using Scaffold.Core.Models;
+using Scaffold.Migration.PostgreSql.Models;
+
+namespace Scaffold.Migration.PostgreSql;
+
+/// <summary>
+/// Migration engine for PostgreSQL → Azure PostgreSQL same-platform migrations.
+/// Orchestrates an 8-step cutover pipeline:
+///   1. Schema extraction (source PG)
+///   2. Extension evaluation + installation (target PG)
+///   3. DDL generation + deployment (target PG)
+///   4. Pre-migration scripts
+///   5. Data copy (PG COPY protocol)
+///   6. Sequence reset
+///   7. Post-migration scripts
+///   8. Validation (row-count comparison)
+///
+/// ContinuousSync will be supported in Wave 4 via logical replication (Issue #34).
+/// </summary>
+public class PostgreSqlMigrator : IMigrationEngine
+{
+    private readonly PostgreSqlSchemaExtractor _schemaExtractor;
+    private readonly PostgreSqlDdlGenerator _ddlGenerator;
+    private readonly PostgreSqlBulkCopier _bulkCopier;
+    private readonly PostgreSqlScriptExecutor _scriptExecutor;
+    private readonly PostgreSqlToPostgreSqlValidationEngine _validationEngine;
+    private readonly AzureExtensionHandler _extensionHandler;
+
+    public PostgreSqlMigrator(
+        PostgreSqlSchemaExtractor schemaExtractor,
+        PostgreSqlDdlGenerator ddlGenerator,
+        PostgreSqlBulkCopier bulkCopier,
+        PostgreSqlScriptExecutor scriptExecutor,
+        PostgreSqlToPostgreSqlValidationEngine validationEngine,
+        AzureExtensionHandler extensionHandler)
+    {
+        _schemaExtractor = schemaExtractor ?? throw new ArgumentNullException(nameof(schemaExtractor));
+        _ddlGenerator = ddlGenerator ?? throw new ArgumentNullException(nameof(ddlGenerator));
+        _bulkCopier = bulkCopier ?? throw new ArgumentNullException(nameof(bulkCopier));
+        _scriptExecutor = scriptExecutor ?? throw new ArgumentNullException(nameof(scriptExecutor));
+        _validationEngine = validationEngine ?? throw new ArgumentNullException(nameof(validationEngine));
+        _extensionHandler = extensionHandler ?? throw new ArgumentNullException(nameof(extensionHandler));
+    }
+
+    public string SourcePlatform => "PostgreSql";
+
+    public async Task<MigrationResult> ExecuteCutoverAsync(
+        MigrationPlan plan,
+        IProgress<MigrationProgress>? progress = null,
+        CancellationToken ct = default)
+    {
+        var result = new MigrationResult
+        {
+            Id = Guid.NewGuid(),
+            ProjectId = plan.ProjectId,
+            StartedAt = DateTime.UtcNow
+        };
+
+        try
+        {
+            ValidateConnectionStrings(plan);
+
+            // Step 1: Extract schema from source PG
+            progress?.Report(new MigrationProgress
+            {
+                Phase = "SchemaExtraction",
+                PercentComplete = 0,
+                Message = "Extracting schema from source PostgreSQL..."
+            });
+
+            var snapshot = await _schemaExtractor.ExtractSchemaAsync(
+                plan.SourceConnectionString!,
+                plan.IncludedObjects.Count > 0 ? plan.IncludedObjects : null,
+                progress,
+                ct);
+
+            // Step 2: Handle extensions (evaluate + install compatible ones on target)
+            progress?.Report(new MigrationProgress
+            {
+                Phase = "Extensions",
+                PercentComplete = 10,
+                Message = "Evaluating and installing PostgreSQL extensions..."
+            });
+
+            var extResult = await _extensionHandler.InstallExtensionsAsync(
+                plan.ExistingTargetConnectionString!,
+                snapshot.Extensions,
+                progress,
+                ct);
+
+            if (!extResult.Success)
+            {
+                result.Success = false;
+                result.Errors.AddRange(
+                    extResult.Warnings
+                        .Where(w => w.Severity == ExtensionWarningSeverity.Error)
+                        .Select(w => w.Message));
+                result.CompletedAt = DateTime.UtcNow;
+                return result;
+            }
+
+            // Step 3: Generate and deploy DDL on target
+            progress?.Report(new MigrationProgress
+            {
+                Phase = "SchemaDeployment",
+                PercentComplete = 15,
+                Message = "Deploying schema to target PostgreSQL..."
+            });
+
+            var ddlStatements = _ddlGenerator.GenerateDdl(snapshot);
+
+            if (ddlStatements.Count > 0)
+            {
+                await using var targetConn = new NpgsqlConnection(plan.ExistingTargetConnectionString);
+                await targetConn.OpenAsync(ct);
+                foreach (var ddl in ddlStatements)
+                {
+                    ct.ThrowIfCancellationRequested();
+                    await using var cmd = new NpgsqlCommand(ddl, targetConn);
+                    cmd.CommandTimeout = plan.ScriptTimeoutSeconds > 0 ? plan.ScriptTimeoutSeconds.Value : 300;
+                    await cmd.ExecuteNonQueryAsync(ct);
+                }
+            }
+
+            // Step 4: Execute pre-migration scripts on target
+            if (plan.PreMigrationScripts.Count > 0)
+            {
+                progress?.Report(new MigrationProgress
+                {
+                    Phase = "PreScripts",
+                    PercentComplete = 25,
+                    Message = "Running pre-migration scripts on target..."
+                });
+                await _scriptExecutor.ExecuteScriptsAsync(
+                    plan.ExistingTargetConnectionString!,
+                    plan.PreMigrationScripts,
+                    progress, ct, plan.ScriptTimeoutSeconds);
+            }
+
+            // Step 5: Copy data (PG → PG via COPY protocol)
+            progress?.Report(new MigrationProgress
+            {
+                Phase = "DataMigration",
+                PercentComplete = 30,
+                Message = "Starting data migration..."
+            });
+
+            var tableNames = snapshot.Tables.Select(t =>
+                $"{PgIdentifierHelper.MapSchema(t.Schema)}.{t.TableName}").ToList();
+
+            var rowsMigrated = await _bulkCopier.CopyDataAsync(
+                plan.SourceConnectionString!,
+                plan.ExistingTargetConnectionString!,
+                tableNames,
+                progress,
+                plan.BulkCopyTimeoutSeconds,
+                ct);
+
+            // Step 6: Reset sequences
+            progress?.Report(new MigrationProgress
+            {
+                Phase = "SequenceReset",
+                PercentComplete = 85,
+                Message = "Resetting sequences..."
+            });
+
+            await _bulkCopier.ResetSequencesAsync(plan.ExistingTargetConnectionString!, ct);
+
+            // Step 7: Execute post-migration scripts
+            if (plan.PostMigrationScripts.Count > 0)
+            {
+                progress?.Report(new MigrationProgress
+                {
+                    Phase = "PostScripts",
+                    PercentComplete = 90,
+                    Message = "Running post-migration scripts on target..."
+                });
+                await _scriptExecutor.ExecuteScriptsAsync(
+                    plan.ExistingTargetConnectionString!,
+                    plan.PostMigrationScripts,
+                    progress, ct, plan.ScriptTimeoutSeconds);
+            }
+
+            // Step 8: Validation
+            progress?.Report(new MigrationProgress
+            {
+                Phase = "Validation",
+                PercentComplete = 95,
+                Message = "Running post-migration validation..."
+            });
+
+            var validationSummary = await _validationEngine.ValidateAsync(
+                plan.SourceConnectionString!,
+                plan.ExistingTargetConnectionString!,
+                tableNames,
+                ct);
+
+            result.RowsMigrated = rowsMigrated;
+            result.Validations = validationSummary.Results;
+            result.Success = validationSummary.AllPassed;
+            result.CompletedAt = DateTime.UtcNow;
+
+            // Extension warnings don't fail migration but are recorded
+            var warningMessages = extResult.Warnings
+                .Where(w => w.Severity != ExtensionWarningSeverity.Error)
+                .Select(w => $"[Warning] {w.Message}")
+                .ToList();
+            if (warningMessages.Count > 0)
+                result.Errors.AddRange(warningMessages);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            result.Success = false;
+            result.Errors.Add(ex.Message);
+            result.CompletedAt = DateTime.UtcNow;
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// ContinuousSync for PG→PG will use logical replication (Wave 4, Issue #34).
+    /// Not yet implemented.
+    /// </summary>
+    public Task StartContinuousSyncAsync(
+        MigrationPlan plan,
+        IProgress<MigrationProgress>? progress = null,
+        CancellationToken ct = default)
+    {
+        throw new NotSupportedException(
+            "Continuous sync for PostgreSQL → PostgreSQL is not yet implemented. It will use logical replication (Issue #34).");
+    }
+
+    public Task<MigrationResult> CompleteCutoverAsync(Guid migrationId, CancellationToken ct = default)
+    {
+        throw new NotSupportedException(
+            "CompleteCutover for PostgreSQL requires an active continuous sync session. Start with StartContinuousSyncAsync first.");
+    }
+
+    private static void ValidateConnectionStrings(MigrationPlan plan)
+    {
+        if (string.IsNullOrWhiteSpace(plan.SourceConnectionString))
+            throw new ArgumentException("SourceConnectionString is required.", nameof(plan));
+        if (string.IsNullOrWhiteSpace(plan.ExistingTargetConnectionString))
+            throw new ArgumentException("ExistingTargetConnectionString is required.", nameof(plan));
+    }
+}

--- a/src/Scaffold.Migration/PostgreSql/PostgreSqlMigrator.cs
+++ b/src/Scaffold.Migration/PostgreSql/PostgreSqlMigrator.cs
@@ -28,6 +28,11 @@ public class PostgreSqlMigrator : IMigrationEngine
     private readonly PostgreSqlToPostgreSqlValidationEngine _validationEngine;
     private readonly AzureExtensionHandler _extensionHandler;
 
+    private LogicalReplicationSyncEngine? _syncEngine;
+    private string? _sourceConnectionString;
+    private string? _targetConnectionString;
+    private MigrationPlan? _activePlan;
+
     public PostgreSqlMigrator(
         PostgreSqlSchemaExtractor schemaExtractor,
         PostgreSqlDdlGenerator ddlGenerator,
@@ -221,22 +226,165 @@ public class PostgreSqlMigrator : IMigrationEngine
     }
 
     /// <summary>
-    /// ContinuousSync for PG→PG will use logical replication (Wave 4, Issue #34).
-    /// Not yet implemented.
+    /// Starts continuous sync for PG→PG using logical replication (pgoutput protocol).
+    /// Extracts schema, deploys DDL, installs extensions, then starts replication.
     /// </summary>
-    public Task StartContinuousSyncAsync(
+    public async Task StartContinuousSyncAsync(
         MigrationPlan plan,
         IProgress<MigrationProgress>? progress = null,
         CancellationToken ct = default)
     {
-        throw new NotSupportedException(
-            "Continuous sync for PostgreSQL → PostgreSQL is not yet implemented. It will use logical replication (Issue #34).");
+        ValidateConnectionStrings(plan);
+
+        _sourceConnectionString = plan.SourceConnectionString!;
+        _targetConnectionString = plan.ExistingTargetConnectionString!;
+        _activePlan = plan;
+
+        // Step 1: Extract schema from source PG
+        progress?.Report(new MigrationProgress
+        {
+            Phase = "SchemaExtraction",
+            PercentComplete = 0,
+            Message = "Extracting schema from source PostgreSQL..."
+        });
+
+        var snapshot = await _schemaExtractor.ExtractSchemaAsync(
+            _sourceConnectionString,
+            plan.IncludedObjects.Count > 0 ? plan.IncludedObjects : null,
+            progress,
+            ct);
+
+        // Step 2: Handle extensions
+        progress?.Report(new MigrationProgress
+        {
+            Phase = "Extensions",
+            PercentComplete = 5,
+            Message = "Evaluating and installing PostgreSQL extensions..."
+        });
+
+        var extResult = await _extensionHandler.InstallExtensionsAsync(
+            _targetConnectionString,
+            snapshot.Extensions,
+            progress,
+            ct);
+
+        if (!extResult.Success)
+        {
+            throw new InvalidOperationException(
+                "Extension installation failed: " +
+                string.Join("; ", extResult.Warnings
+                    .Where(w => w.Severity == ExtensionWarningSeverity.Error)
+                    .Select(w => w.Message)));
+        }
+
+        // Step 3: Deploy DDL on target
+        progress?.Report(new MigrationProgress
+        {
+            Phase = "SchemaDeployment",
+            PercentComplete = 10,
+            Message = "Deploying schema to target PostgreSQL..."
+        });
+
+        var ddlStatements = _ddlGenerator.GenerateDdl(snapshot);
+
+        if (ddlStatements.Count > 0)
+        {
+            await using var targetConn = new NpgsqlConnection(_targetConnectionString);
+            await targetConn.OpenAsync(ct);
+            foreach (var ddl in ddlStatements)
+            {
+                ct.ThrowIfCancellationRequested();
+                await using var cmd = new NpgsqlCommand(ddl, targetConn);
+                cmd.CommandTimeout = plan.ScriptTimeoutSeconds > 0 ? plan.ScriptTimeoutSeconds.Value : 300;
+                await cmd.ExecuteNonQueryAsync(ct);
+            }
+        }
+
+        // Step 4: Execute pre-migration scripts
+        if (plan.PreMigrationScripts.Count > 0)
+        {
+            progress?.Report(new MigrationProgress
+            {
+                Phase = "PreScripts",
+                PercentComplete = 15,
+                Message = "Running pre-migration scripts on target..."
+            });
+            await _scriptExecutor.ExecuteScriptsAsync(
+                _targetConnectionString,
+                plan.PreMigrationScripts,
+                progress, ct, plan.ScriptTimeoutSeconds);
+        }
+
+        // Step 5: Start logical replication sync engine
+        progress?.Report(new MigrationProgress
+        {
+            Phase = "ContinuousSync",
+            PercentComplete = 20,
+            Message = "Starting logical replication sync..."
+        });
+
+        var tableNames = snapshot.Tables.Select(t =>
+            $"{PgIdentifierHelper.MapSchema(t.Schema)}.{t.TableName}").ToList();
+
+        _syncEngine = new LogicalReplicationSyncEngine(_bulkCopier, progress);
+        await _syncEngine.StartAsync(
+            _sourceConnectionString,
+            _targetConnectionString,
+            tableNames,
+            plan.MigrationId ?? plan.Id,
+            ct);
+
+        progress?.Report(new MigrationProgress
+        {
+            Phase = "ContinuousSync",
+            PercentComplete = 50,
+            Message = "Logical replication streaming active. Ready for cutover."
+        });
     }
 
-    public Task<MigrationResult> CompleteCutoverAsync(Guid migrationId, CancellationToken ct = default)
+    /// <summary>
+    /// Completes cutover by stopping replication, running post-scripts, and validating.
+    /// </summary>
+    public async Task<MigrationResult> CompleteCutoverAsync(Guid migrationId, CancellationToken ct = default)
     {
-        throw new NotSupportedException(
-            "CompleteCutover for PostgreSQL requires an active continuous sync session. Start with StartContinuousSyncAsync first.");
+        if (_syncEngine is null)
+        {
+            throw new InvalidOperationException(
+                "Cannot complete cutover before starting continuous sync. Call StartContinuousSyncAsync first.");
+        }
+
+        var result = await _syncEngine.CompleteCutoverAsync(
+            _activePlan?.ProjectId ?? Guid.Empty, ct);
+
+        // Run post-migration scripts if configured
+        if (_activePlan?.PostMigrationScripts.Count > 0)
+        {
+            await _scriptExecutor.ExecuteScriptsAsync(
+                _targetConnectionString!,
+                _activePlan.PostMigrationScripts,
+                null, ct, _activePlan.ScriptTimeoutSeconds);
+        }
+
+        // Run validation
+        if (_activePlan is not null)
+        {
+            var snapshot = await _schemaExtractor.ExtractSchemaAsync(
+                _sourceConnectionString!, ct: ct);
+            var tableNames = snapshot.Tables.Select(t =>
+                $"{PgIdentifierHelper.MapSchema(t.Schema)}.{t.TableName}").ToList();
+
+            var validationSummary = await _validationEngine.ValidateAsync(
+                _sourceConnectionString!,
+                _targetConnectionString!,
+                tableNames,
+                ct);
+
+            result.Validations = validationSummary.Results;
+            result.Success = validationSummary.AllPassed;
+        }
+
+        result.CompletedAt = DateTime.UtcNow;
+        return result;
     }
 
     private static void ValidateConnectionStrings(MigrationPlan plan)

--- a/src/Scaffold.Migration/PostgreSql/PostgreSqlMigrator.cs
+++ b/src/Scaffold.Migration/PostgreSql/PostgreSqlMigrator.cs
@@ -106,7 +106,7 @@ public class PostgreSqlMigrator : IMigrationEngine
                 return result;
             }
 
-            // Step 3: Generate and deploy DDL on target
+            // Step 3: Generate and deploy DDL on target (wrapped in transaction)
             progress?.Report(new MigrationProgress
             {
                 Phase = "SchemaDeployment",
@@ -120,12 +120,22 @@ public class PostgreSqlMigrator : IMigrationEngine
             {
                 await using var targetConn = new NpgsqlConnection(plan.ExistingTargetConnectionString);
                 await targetConn.OpenAsync(ct);
-                foreach (var ddl in ddlStatements)
+                await using var transaction = await targetConn.BeginTransactionAsync(ct);
+                try
                 {
-                    ct.ThrowIfCancellationRequested();
-                    await using var cmd = new NpgsqlCommand(ddl, targetConn);
-                    cmd.CommandTimeout = plan.ScriptTimeoutSeconds > 0 ? plan.ScriptTimeoutSeconds.Value : 300;
-                    await cmd.ExecuteNonQueryAsync(ct);
+                    foreach (var ddl in ddlStatements)
+                    {
+                        ct.ThrowIfCancellationRequested();
+                        await using var cmd = new NpgsqlCommand(ddl, targetConn, transaction);
+                        cmd.CommandTimeout = plan.ScriptTimeoutSeconds > 0 ? plan.ScriptTimeoutSeconds.Value : 300;
+                        await cmd.ExecuteNonQueryAsync(ct);
+                    }
+                    await transaction.CommitAsync(ct);
+                }
+                catch
+                {
+                    await transaction.RollbackAsync(ct);
+                    throw;
                 }
             }
 
@@ -277,7 +287,7 @@ public class PostgreSqlMigrator : IMigrationEngine
                     .Select(w => w.Message)));
         }
 
-        // Step 3: Deploy DDL on target
+        // Step 3: Deploy DDL on target (wrapped in transaction)
         progress?.Report(new MigrationProgress
         {
             Phase = "SchemaDeployment",
@@ -291,12 +301,22 @@ public class PostgreSqlMigrator : IMigrationEngine
         {
             await using var targetConn = new NpgsqlConnection(_targetConnectionString);
             await targetConn.OpenAsync(ct);
-            foreach (var ddl in ddlStatements)
+            await using var transaction = await targetConn.BeginTransactionAsync(ct);
+            try
             {
-                ct.ThrowIfCancellationRequested();
-                await using var cmd = new NpgsqlCommand(ddl, targetConn);
-                cmd.CommandTimeout = plan.ScriptTimeoutSeconds > 0 ? plan.ScriptTimeoutSeconds.Value : 300;
-                await cmd.ExecuteNonQueryAsync(ct);
+                foreach (var ddl in ddlStatements)
+                {
+                    ct.ThrowIfCancellationRequested();
+                    await using var cmd = new NpgsqlCommand(ddl, targetConn, transaction);
+                    cmd.CommandTimeout = plan.ScriptTimeoutSeconds > 0 ? plan.ScriptTimeoutSeconds.Value : 300;
+                    await cmd.ExecuteNonQueryAsync(ct);
+                }
+                await transaction.CommitAsync(ct);
+            }
+            catch
+            {
+                await transaction.RollbackAsync(ct);
+                throw;
             }
         }
 
@@ -355,6 +375,10 @@ public class PostgreSqlMigrator : IMigrationEngine
 
         var result = await _syncEngine.CompleteCutoverAsync(
             _activePlan?.ProjectId ?? Guid.Empty, ct);
+
+        // Dispose the sync engine after cutover
+        await _syncEngine.DisposeAsync();
+        _syncEngine = null;
 
         // Run post-migration scripts if configured
         if (_activePlan?.PostMigrationScripts.Count > 0)

--- a/src/Scaffold.Migration/PostgreSql/PostgreSqlSchemaExtractor.cs
+++ b/src/Scaffold.Migration/PostgreSql/PostgreSqlSchemaExtractor.cs
@@ -207,7 +207,7 @@ public class PostgreSqlSchemaExtractor
                    c.character_maximum_length, c.numeric_precision, c.numeric_scale,
                    c.is_nullable, c.column_default, c.ordinal_position,
                    c.is_identity, c.identity_generation, c.is_generated, c.generation_expression,
-                   c.collation_name
+                   c.collation_name, c.udt_schema
             FROM information_schema.columns c
             JOIN information_schema.tables t
               ON c.table_schema = t.table_schema AND c.table_name = t.table_name
@@ -253,12 +253,13 @@ public class PostgreSqlSchemaExtractor
         var maxLength = reader.IsDBNull(5) ? (int?)null : reader.GetInt32(5);
         var precision = reader.IsDBNull(6) ? (int?)null : reader.GetInt32(6);
         var scale = reader.IsDBNull(7) ? (int?)null : reader.GetInt32(7);
+        var udtSchema = reader.IsDBNull(16) ? null : reader.GetString(16);
 
         return new PgColumnDefinition
         {
             Name = reader.GetString(2),
             DataType = dataType,
-            FullType = BuildFullType(dataType, udtName, maxLength, precision, scale),
+            FullType = BuildFullType(dataType, udtName, maxLength, precision, scale, udtSchema),
             MaxLength = maxLength,
             Precision = precision,
             Scale = scale,
@@ -270,19 +271,27 @@ public class PostgreSqlSchemaExtractor
             IsGenerated = reader.GetString(13) != "NEVER",
             GenerationExpression = reader.IsDBNull(14) ? null : reader.GetString(14),
             Collation = reader.IsDBNull(15) ? null : reader.GetString(15),
-            UdtName = udtName
+            UdtName = udtName,
+            UdtSchema = udtSchema
         };
     }
 
     /// <summary>
     /// Builds the full type string with modifiers (e.g., "character varying(255)").
+    /// Schema-qualifies USER-DEFINED types when they are outside the "public" schema.
     /// </summary>
     internal static string BuildFullType(
-        string dataType, string? udtName, int? maxLength, int? precision, int? scale)
+        string dataType, string? udtName, int? maxLength, int? precision, int? scale,
+        string? udtSchema = null)
     {
-        // USER-DEFINED types (enums, composites, domains) — use the UDT name
+        // USER-DEFINED types (enums, composites, domains) — use the UDT name, schema-qualified
         if (dataType.Equals("USER-DEFINED", StringComparison.OrdinalIgnoreCase) && udtName != null)
-            return udtName;
+        {
+            var effectiveSchema = udtSchema ?? "public";
+            if (effectiveSchema.Equals("public", StringComparison.OrdinalIgnoreCase))
+                return PgIdentifierHelper.QuoteIdentifier(udtName);
+            return $"{PgIdentifierHelper.QuoteIdentifier(effectiveSchema)}.{PgIdentifierHelper.QuoteIdentifier(udtName)}";
+        }
 
         // ARRAY types — use UDT name (e.g., "_int4" → "integer[]")
         if (dataType.Equals("ARRAY", StringComparison.OrdinalIgnoreCase) && udtName != null)
@@ -345,21 +354,22 @@ public class PostgreSqlSchemaExtractor
         Dictionary<string, PgTableDefinition> tableMap,
         CancellationToken ct)
     {
+        // Use pg_constraint with unnest to get positionally-correct column pairs,
+        // avoiding the Cartesian product from information_schema joins on composite FKs.
         const string sql = """
-            SELECT tc.table_schema, tc.table_name, tc.constraint_name,
-                   kcu.column_name, ccu.table_schema AS ref_schema, ccu.table_name AS ref_table,
-                   ccu.column_name AS ref_column,
-                   rc.delete_rule, rc.update_rule
-            FROM information_schema.table_constraints tc
-            JOIN information_schema.key_column_usage kcu
-              ON tc.constraint_name = kcu.constraint_name AND tc.table_schema = kcu.table_schema
-            JOIN information_schema.constraint_column_usage ccu
-              ON tc.constraint_name = ccu.constraint_name AND tc.table_schema = ccu.table_schema
-            JOIN information_schema.referential_constraints rc
-              ON tc.constraint_name = rc.constraint_name AND tc.table_schema = rc.constraint_schema
-            WHERE tc.constraint_type = 'FOREIGN KEY'
-              AND tc.table_schema NOT IN ('pg_catalog', 'information_schema')
-            ORDER BY tc.table_schema, tc.table_name, kcu.ordinal_position
+            SELECT n.nspname AS table_schema, c.relname AS table_name, con.conname AS constraint_name,
+                   a_src.attname AS column_name, rn.nspname AS ref_schema, rc.relname AS ref_table,
+                   a_ref.attname AS ref_column, con.confdeltype, con.confupdtype
+            FROM pg_constraint con
+            JOIN pg_class c ON con.conrelid = c.oid
+            JOIN pg_namespace n ON c.relnamespace = n.oid
+            JOIN pg_class rc ON con.confrelid = rc.oid
+            JOIN pg_namespace rn ON rc.relnamespace = rn.oid
+            CROSS JOIN LATERAL unnest(con.conkey, con.confkey) WITH ORDINALITY AS u(src_attnum, ref_attnum, ord)
+            JOIN pg_attribute a_src ON a_src.attrelid = con.conrelid AND a_src.attnum = u.src_attnum
+            JOIN pg_attribute a_ref ON a_ref.attrelid = con.confrelid AND a_ref.attnum = u.ref_attnum
+            WHERE con.contype = 'f' AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+            ORDER BY n.nspname, c.relname, con.conname, u.ord
             """;
 
         var fkMap = new Dictionary<string, PgForeignKeyDefinition>(StringComparer.OrdinalIgnoreCase);
@@ -382,22 +392,31 @@ public class PostgreSqlSchemaExtractor
                     Name = fkName,
                     ReferencedSchema = reader.GetString(4),
                     ReferencedTable = reader.GetString(5),
-                    DeleteAction = reader.GetString(7),
-                    UpdateAction = reader.GetString(8)
+                    DeleteAction = MapFkAction(reader.GetChar(7)),
+                    UpdateAction = MapFkAction(reader.GetChar(8))
                 };
                 fkMap[fkKey] = fk;
                 table.ForeignKeys.Add(fk);
             }
 
-            var column = reader.GetString(3);
-            if (!fk.Columns.Contains(column, StringComparer.OrdinalIgnoreCase))
-                fk.Columns.Add(column);
-
-            var refColumn = reader.GetString(6);
-            if (!fk.ReferencedColumns.Contains(refColumn, StringComparer.OrdinalIgnoreCase))
-                fk.ReferencedColumns.Add(refColumn);
+            // Each row is one (source_col, ref_col) pair in ordinal position — no dedup needed
+            fk.Columns.Add(reader.GetString(3));
+            fk.ReferencedColumns.Add(reader.GetString(6));
         }
     }
+
+    /// <summary>
+    /// Maps pg_constraint FK action characters to SQL standard action strings.
+    /// </summary>
+    internal static string MapFkAction(char action) => action switch
+    {
+        'a' => "NO ACTION",
+        'r' => "RESTRICT",
+        'c' => "CASCADE",
+        'n' => "SET NULL",
+        'd' => "SET DEFAULT",
+        _ => "NO ACTION"
+    };
 
     internal static async Task ReadUniqueConstraintsAsync(
         NpgsqlConnection connection,

--- a/src/Scaffold.Migration/PostgreSql/PostgreSqlSchemaExtractor.cs
+++ b/src/Scaffold.Migration/PostgreSql/PostgreSqlSchemaExtractor.cs
@@ -1,0 +1,715 @@
+using Npgsql;
+using Scaffold.Core.Interfaces;
+using Scaffold.Migration.PostgreSql.Models;
+
+namespace Scaffold.Migration.PostgreSql;
+
+/// <summary>
+/// Reads schema from a PostgreSQL source database and produces PG-native model objects.
+/// Queries pg_catalog and information_schema to extract tables, views, functions,
+/// sequences, enum types, indexes, and extensions.
+/// </summary>
+public class PostgreSqlSchemaExtractor
+{
+    /// <summary>
+    /// Extracts full schema from a PostgreSQL database.
+    /// </summary>
+    /// <param name="connectionString">PostgreSQL connection string.</param>
+    /// <param name="includedObjects">Optional filter: only include tables matching these schema.table names.</param>
+    /// <param name="progress">Optional progress reporter.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A snapshot of the database schema.</returns>
+    public virtual async Task<PgSchemaSnapshot> ExtractSchemaAsync(
+        string connectionString,
+        IReadOnlyList<string>? includedObjects = null,
+        IProgress<MigrationProgress>? progress = null,
+        CancellationToken ct = default)
+    {
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(ct);
+
+        var snapshot = new PgSchemaSnapshot();
+
+        progress?.Report(new MigrationProgress
+        {
+            Phase = "SchemaExtraction",
+            PercentComplete = 0,
+            Message = "Extracting extensions..."
+        });
+
+        snapshot.Extensions = await ReadExtensionsAsync(connection, ct);
+
+        progress?.Report(new MigrationProgress
+        {
+            Phase = "SchemaExtraction",
+            PercentComplete = 10,
+            Message = "Extracting enum types..."
+        });
+
+        snapshot.EnumTypes = await ReadEnumTypesAsync(connection, ct);
+
+        progress?.Report(new MigrationProgress
+        {
+            Phase = "SchemaExtraction",
+            PercentComplete = 20,
+            Message = "Extracting tables and columns..."
+        });
+
+        snapshot.Tables = await ReadTablesAndColumnsAsync(connection, includedObjects, ct);
+        var tableMap = snapshot.Tables.ToDictionary(
+            t => t.QualifiedName, StringComparer.OrdinalIgnoreCase);
+
+        progress?.Report(new MigrationProgress
+        {
+            Phase = "SchemaExtraction",
+            PercentComplete = 40,
+            Message = "Extracting primary keys..."
+        });
+
+        await ReadPrimaryKeysAsync(connection, tableMap, ct);
+
+        progress?.Report(new MigrationProgress
+        {
+            Phase = "SchemaExtraction",
+            PercentComplete = 50,
+            Message = "Extracting foreign keys..."
+        });
+
+        await ReadForeignKeysAsync(connection, tableMap, ct);
+
+        progress?.Report(new MigrationProgress
+        {
+            Phase = "SchemaExtraction",
+            PercentComplete = 55,
+            Message = "Extracting unique constraints..."
+        });
+
+        await ReadUniqueConstraintsAsync(connection, tableMap, ct);
+
+        progress?.Report(new MigrationProgress
+        {
+            Phase = "SchemaExtraction",
+            PercentComplete = 60,
+            Message = "Extracting check constraints..."
+        });
+
+        await ReadCheckConstraintsAsync(connection, tableMap, ct);
+
+        progress?.Report(new MigrationProgress
+        {
+            Phase = "SchemaExtraction",
+            PercentComplete = 65,
+            Message = "Extracting indexes..."
+        });
+
+        await ReadIndexesAsync(connection, tableMap, ct);
+
+        progress?.Report(new MigrationProgress
+        {
+            Phase = "SchemaExtraction",
+            PercentComplete = 75,
+            Message = "Extracting sequences..."
+        });
+
+        snapshot.Sequences = await ReadSequencesAsync(connection, ct);
+
+        progress?.Report(new MigrationProgress
+        {
+            Phase = "SchemaExtraction",
+            PercentComplete = 85,
+            Message = "Extracting views..."
+        });
+
+        snapshot.Views = await ReadViewsAsync(connection, ct);
+
+        progress?.Report(new MigrationProgress
+        {
+            Phase = "SchemaExtraction",
+            PercentComplete = 95,
+            Message = "Extracting functions..."
+        });
+
+        snapshot.Functions = await ReadFunctionsAsync(connection, ct);
+
+        progress?.Report(new MigrationProgress
+        {
+            Phase = "SchemaExtraction",
+            PercentComplete = 100,
+            Message = "Schema extraction complete."
+        });
+
+        return snapshot;
+    }
+
+    internal static async Task<List<string>> ReadExtensionsAsync(
+        NpgsqlConnection connection, CancellationToken ct)
+    {
+        const string sql = "SELECT extname FROM pg_extension WHERE extname != 'plpgsql'";
+
+        var extensions = new List<string>();
+        await using var cmd = new NpgsqlCommand(sql, connection);
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+
+        while (await reader.ReadAsync(ct))
+        {
+            extensions.Add(reader.GetString(0));
+        }
+
+        return extensions;
+    }
+
+    internal static async Task<List<PgEnumTypeDefinition>> ReadEnumTypesAsync(
+        NpgsqlConnection connection, CancellationToken ct)
+    {
+        const string sql = """
+            SELECT n.nspname AS schema, t.typname AS name,
+                   e.enumlabel AS label, e.enumsortorder
+            FROM pg_type t
+            JOIN pg_enum e ON t.oid = e.enumtypid
+            JOIN pg_namespace n ON t.typnamespace = n.oid
+            WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
+            ORDER BY n.nspname, t.typname, e.enumsortorder
+            """;
+
+        var enums = new List<PgEnumTypeDefinition>();
+        var enumMap = new Dictionary<string, PgEnumTypeDefinition>(StringComparer.OrdinalIgnoreCase);
+
+        await using var cmd = new NpgsqlCommand(sql, connection);
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+
+        while (await reader.ReadAsync(ct))
+        {
+            var schema = reader.GetString(0);
+            var name = reader.GetString(1);
+            var label = reader.GetString(2);
+            var key = $"{schema}.{name}";
+
+            if (!enumMap.TryGetValue(key, out var enumDef))
+            {
+                enumDef = new PgEnumTypeDefinition { Schema = schema, Name = name };
+                enumMap[key] = enumDef;
+                enums.Add(enumDef);
+            }
+
+            enumDef.Labels.Add(label);
+        }
+
+        return enums;
+    }
+
+    internal static async Task<List<PgTableDefinition>> ReadTablesAndColumnsAsync(
+        NpgsqlConnection connection,
+        IReadOnlyList<string>? includedObjects,
+        CancellationToken ct)
+    {
+        const string sql = """
+            SELECT c.table_schema, c.table_name, c.column_name, c.data_type, c.udt_name,
+                   c.character_maximum_length, c.numeric_precision, c.numeric_scale,
+                   c.is_nullable, c.column_default, c.ordinal_position,
+                   c.is_identity, c.identity_generation, c.is_generated, c.generation_expression,
+                   c.collation_name
+            FROM information_schema.columns c
+            JOIN information_schema.tables t
+              ON c.table_schema = t.table_schema AND c.table_name = t.table_name
+            WHERE t.table_type = 'BASE TABLE'
+              AND c.table_schema NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
+            ORDER BY c.table_schema, c.table_name, c.ordinal_position
+            """;
+
+        var tables = new List<PgTableDefinition>();
+        var tableMap = new Dictionary<string, PgTableDefinition>(StringComparer.OrdinalIgnoreCase);
+
+        await using var cmd = new NpgsqlCommand(sql, connection);
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+
+        while (await reader.ReadAsync(ct))
+        {
+            var schema = reader.GetString(0);
+            var tableName = reader.GetString(1);
+            var qualifiedName = $"{schema}.{tableName}";
+
+            if (includedObjects is { Count: > 0 } &&
+                !IsObjectIncluded(schema, tableName, includedObjects))
+                continue;
+
+            if (!tableMap.TryGetValue(qualifiedName, out var table))
+            {
+                table = new PgTableDefinition { Schema = schema, TableName = tableName };
+                tableMap[qualifiedName] = table;
+                tables.Add(table);
+            }
+
+            var column = BuildColumnDefinition(reader);
+            table.Columns.Add(column);
+        }
+
+        return tables;
+    }
+
+    internal static PgColumnDefinition BuildColumnDefinition(NpgsqlDataReader reader)
+    {
+        var dataType = reader.GetString(3);
+        var udtName = reader.IsDBNull(4) ? null : reader.GetString(4);
+        var maxLength = reader.IsDBNull(5) ? (int?)null : reader.GetInt32(5);
+        var precision = reader.IsDBNull(6) ? (int?)null : reader.GetInt32(6);
+        var scale = reader.IsDBNull(7) ? (int?)null : reader.GetInt32(7);
+
+        return new PgColumnDefinition
+        {
+            Name = reader.GetString(2),
+            DataType = dataType,
+            FullType = BuildFullType(dataType, udtName, maxLength, precision, scale),
+            MaxLength = maxLength,
+            Precision = precision,
+            Scale = scale,
+            IsNullable = reader.GetString(8) == "YES",
+            DefaultExpression = reader.IsDBNull(9) ? null : reader.GetString(9),
+            OrdinalPosition = reader.GetInt32(10),
+            IsIdentity = reader.GetString(11) == "YES",
+            IdentityGeneration = reader.IsDBNull(12) ? null : reader.GetString(12),
+            IsGenerated = reader.GetString(13) != "NEVER",
+            GenerationExpression = reader.IsDBNull(14) ? null : reader.GetString(14),
+            Collation = reader.IsDBNull(15) ? null : reader.GetString(15),
+            UdtName = udtName
+        };
+    }
+
+    /// <summary>
+    /// Builds the full type string with modifiers (e.g., "character varying(255)").
+    /// </summary>
+    internal static string BuildFullType(
+        string dataType, string? udtName, int? maxLength, int? precision, int? scale)
+    {
+        // USER-DEFINED types (enums, composites, domains) — use the UDT name
+        if (dataType.Equals("USER-DEFINED", StringComparison.OrdinalIgnoreCase) && udtName != null)
+            return udtName;
+
+        // ARRAY types — use UDT name (e.g., "_int4" → "integer[]")
+        if (dataType.Equals("ARRAY", StringComparison.OrdinalIgnoreCase) && udtName != null)
+            return udtName.StartsWith('_') ? udtName[1..] + "[]" : udtName + "[]";
+
+        // character varying / character with length
+        if (dataType is "character varying" && maxLength.HasValue)
+            return $"character varying({maxLength.Value})";
+        if (dataType is "character" && maxLength.HasValue)
+            return $"character({maxLength.Value})";
+
+        // numeric/decimal with precision and scale
+        if (dataType is "numeric" or "decimal" && precision.HasValue)
+            return scale.HasValue && scale.Value > 0
+                ? $"numeric({precision.Value},{scale.Value})"
+                : $"numeric({precision.Value})";
+
+        // bit / bit varying with length
+        if (dataType is "bit" && maxLength.HasValue)
+            return $"bit({maxLength.Value})";
+        if (dataType is "bit varying" && maxLength.HasValue)
+            return $"bit varying({maxLength.Value})";
+
+        return dataType;
+    }
+
+    internal static async Task ReadPrimaryKeysAsync(
+        NpgsqlConnection connection,
+        Dictionary<string, PgTableDefinition> tableMap,
+        CancellationToken ct)
+    {
+        const string sql = """
+            SELECT tc.table_schema, tc.table_name, tc.constraint_name, kcu.column_name
+            FROM information_schema.table_constraints tc
+            JOIN information_schema.key_column_usage kcu
+              ON tc.constraint_name = kcu.constraint_name AND tc.table_schema = kcu.table_schema
+            WHERE tc.constraint_type = 'PRIMARY KEY'
+              AND tc.table_schema NOT IN ('pg_catalog', 'information_schema')
+            ORDER BY tc.table_schema, tc.table_name, kcu.ordinal_position
+            """;
+
+        await using var cmd = new NpgsqlCommand(sql, connection);
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+
+        while (await reader.ReadAsync(ct))
+        {
+            var key = $"{reader.GetString(0)}.{reader.GetString(1)}";
+            if (!tableMap.TryGetValue(key, out var table)) continue;
+
+            table.PrimaryKey ??= new PgPrimaryKeyDefinition
+            {
+                Name = reader.GetString(2)
+            };
+            table.PrimaryKey.Columns.Add(reader.GetString(3));
+        }
+    }
+
+    internal static async Task ReadForeignKeysAsync(
+        NpgsqlConnection connection,
+        Dictionary<string, PgTableDefinition> tableMap,
+        CancellationToken ct)
+    {
+        const string sql = """
+            SELECT tc.table_schema, tc.table_name, tc.constraint_name,
+                   kcu.column_name, ccu.table_schema AS ref_schema, ccu.table_name AS ref_table,
+                   ccu.column_name AS ref_column,
+                   rc.delete_rule, rc.update_rule
+            FROM information_schema.table_constraints tc
+            JOIN information_schema.key_column_usage kcu
+              ON tc.constraint_name = kcu.constraint_name AND tc.table_schema = kcu.table_schema
+            JOIN information_schema.constraint_column_usage ccu
+              ON tc.constraint_name = ccu.constraint_name AND tc.table_schema = ccu.table_schema
+            JOIN information_schema.referential_constraints rc
+              ON tc.constraint_name = rc.constraint_name AND tc.table_schema = rc.constraint_schema
+            WHERE tc.constraint_type = 'FOREIGN KEY'
+              AND tc.table_schema NOT IN ('pg_catalog', 'information_schema')
+            ORDER BY tc.table_schema, tc.table_name, kcu.ordinal_position
+            """;
+
+        var fkMap = new Dictionary<string, PgForeignKeyDefinition>(StringComparer.OrdinalIgnoreCase);
+
+        await using var cmd = new NpgsqlCommand(sql, connection);
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+
+        while (await reader.ReadAsync(ct))
+        {
+            var key = $"{reader.GetString(0)}.{reader.GetString(1)}";
+            if (!tableMap.TryGetValue(key, out var table)) continue;
+
+            var fkName = reader.GetString(2);
+            var fkKey = $"{key}.{fkName}";
+
+            if (!fkMap.TryGetValue(fkKey, out var fk))
+            {
+                fk = new PgForeignKeyDefinition
+                {
+                    Name = fkName,
+                    ReferencedSchema = reader.GetString(4),
+                    ReferencedTable = reader.GetString(5),
+                    DeleteAction = reader.GetString(7),
+                    UpdateAction = reader.GetString(8)
+                };
+                fkMap[fkKey] = fk;
+                table.ForeignKeys.Add(fk);
+            }
+
+            var column = reader.GetString(3);
+            if (!fk.Columns.Contains(column, StringComparer.OrdinalIgnoreCase))
+                fk.Columns.Add(column);
+
+            var refColumn = reader.GetString(6);
+            if (!fk.ReferencedColumns.Contains(refColumn, StringComparer.OrdinalIgnoreCase))
+                fk.ReferencedColumns.Add(refColumn);
+        }
+    }
+
+    internal static async Task ReadUniqueConstraintsAsync(
+        NpgsqlConnection connection,
+        Dictionary<string, PgTableDefinition> tableMap,
+        CancellationToken ct)
+    {
+        const string sql = """
+            SELECT tc.table_schema, tc.table_name, tc.constraint_name, kcu.column_name
+            FROM information_schema.table_constraints tc
+            JOIN information_schema.key_column_usage kcu
+              ON tc.constraint_name = kcu.constraint_name AND tc.table_schema = kcu.table_schema
+            WHERE tc.constraint_type = 'UNIQUE'
+              AND tc.table_schema NOT IN ('pg_catalog', 'information_schema')
+            ORDER BY tc.table_schema, tc.table_name, kcu.ordinal_position
+            """;
+
+        var uqMap = new Dictionary<string, PgUniqueConstraintDefinition>(StringComparer.OrdinalIgnoreCase);
+
+        await using var cmd = new NpgsqlCommand(sql, connection);
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+
+        while (await reader.ReadAsync(ct))
+        {
+            var key = $"{reader.GetString(0)}.{reader.GetString(1)}";
+            if (!tableMap.TryGetValue(key, out var table)) continue;
+
+            var uqName = reader.GetString(2);
+            var uqKey = $"{key}.{uqName}";
+
+            if (!uqMap.TryGetValue(uqKey, out var uq))
+            {
+                uq = new PgUniqueConstraintDefinition { Name = uqName };
+                uqMap[uqKey] = uq;
+                table.UniqueConstraints.Add(uq);
+            }
+
+            uq.Columns.Add(reader.GetString(3));
+        }
+    }
+
+    internal static async Task ReadCheckConstraintsAsync(
+        NpgsqlConnection connection,
+        Dictionary<string, PgTableDefinition> tableMap,
+        CancellationToken ct)
+    {
+        const string sql = """
+            SELECT tc.table_schema, tc.table_name, tc.constraint_name, cc.check_clause
+            FROM information_schema.table_constraints tc
+            JOIN information_schema.check_constraints cc
+              ON tc.constraint_name = cc.constraint_name AND tc.constraint_schema = cc.constraint_schema
+            WHERE tc.constraint_type = 'CHECK'
+              AND tc.table_schema NOT IN ('pg_catalog', 'information_schema')
+              AND cc.check_clause NOT LIKE '%IS NOT NULL%'
+            """;
+
+        await using var cmd = new NpgsqlCommand(sql, connection);
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+
+        while (await reader.ReadAsync(ct))
+        {
+            var key = $"{reader.GetString(0)}.{reader.GetString(1)}";
+            if (!tableMap.TryGetValue(key, out var table)) continue;
+
+            table.CheckConstraints.Add(new PgCheckConstraintDefinition
+            {
+                Name = reader.GetString(2),
+                Expression = reader.GetString(3)
+            });
+        }
+    }
+
+    internal static async Task ReadIndexesAsync(
+        NpgsqlConnection connection,
+        Dictionary<string, PgTableDefinition> tableMap,
+        CancellationToken ct)
+    {
+        // First, collect constraint-backing index names to skip
+        const string constraintSql = """
+            SELECT tc.table_schema, tc.table_name, tc.constraint_name
+            FROM information_schema.table_constraints tc
+            WHERE tc.constraint_type IN ('PRIMARY KEY', 'UNIQUE')
+              AND tc.table_schema NOT IN ('pg_catalog', 'information_schema')
+            """;
+
+        var constraintIndexes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        await using (var constraintCmd = new NpgsqlCommand(constraintSql, connection))
+        await using (var constraintReader = await constraintCmd.ExecuteReaderAsync(ct))
+        {
+            while (await constraintReader.ReadAsync(ct))
+            {
+                constraintIndexes.Add(constraintReader.GetString(2));
+            }
+        }
+
+        // Now read all indexes
+        const string sql = """
+            SELECT schemaname, tablename, indexname, indexdef
+            FROM pg_indexes
+            WHERE schemaname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
+            """;
+
+        await using var cmd = new NpgsqlCommand(sql, connection);
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+
+        while (await reader.ReadAsync(ct))
+        {
+            var schema = reader.GetString(0);
+            var tableName = reader.GetString(1);
+            var indexName = reader.GetString(2);
+            var indexDef = reader.GetString(3);
+
+            // Skip indexes that back PK or UNIQUE constraints
+            if (constraintIndexes.Contains(indexName))
+                continue;
+
+            var key = $"{schema}.{tableName}";
+            if (!tableMap.TryGetValue(key, out var table)) continue;
+
+            var index = ParseIndexDefinition(indexName, indexDef);
+            table.Indexes.Add(index);
+        }
+    }
+
+    /// <summary>
+    /// Parses a CREATE INDEX DDL string to extract columns, uniqueness, access method, and filter.
+    /// Falls back to storing the raw DDL when parsing fails.
+    /// </summary>
+    internal static PgIndexDefinition ParseIndexDefinition(string indexName, string indexDef)
+    {
+        var index = new PgIndexDefinition
+        {
+            Name = indexName,
+            RawDdl = indexDef
+        };
+
+        // Determine uniqueness
+        index.IsUnique = indexDef.StartsWith("CREATE UNIQUE", StringComparison.OrdinalIgnoreCase);
+
+        // Extract access method: USING btree|hash|gin|gist|...
+        var usingIdx = indexDef.IndexOf(" USING ", StringComparison.OrdinalIgnoreCase);
+        if (usingIdx >= 0)
+        {
+            var afterUsing = indexDef[(usingIdx + 7)..];
+            var spaceIdx = afterUsing.IndexOf(' ');
+            if (spaceIdx > 0)
+                index.AccessMethod = afterUsing[..spaceIdx].Trim();
+        }
+
+        // Extract column list from parentheses after USING method
+        var parenStart = indexDef.IndexOf('(');
+        if (parenStart >= 0)
+        {
+            var parenEnd = FindMatchingParen(indexDef, parenStart);
+            if (parenEnd > parenStart)
+            {
+                var colSection = indexDef[(parenStart + 1)..parenEnd];
+                index.Columns = colSection
+                    .Split(',')
+                    .Select(c => c.Trim())
+                    .Where(c => !string.IsNullOrEmpty(c))
+                    .ToList();
+            }
+        }
+
+        // Extract WHERE clause (partial index filter)
+        var whereIdx = indexDef.IndexOf(" WHERE ", StringComparison.OrdinalIgnoreCase);
+        if (whereIdx >= 0)
+        {
+            index.FilterExpression = indexDef[(whereIdx + 7)..].TrimEnd(';').Trim();
+        }
+
+        return index;
+    }
+
+    private static int FindMatchingParen(string text, int openIndex)
+    {
+        var depth = 0;
+        for (var i = openIndex; i < text.Length; i++)
+        {
+            if (text[i] == '(') depth++;
+            else if (text[i] == ')') depth--;
+            if (depth == 0) return i;
+        }
+        return -1;
+    }
+
+    internal static async Task<List<PgSequenceDefinition>> ReadSequencesAsync(
+        NpgsqlConnection connection, CancellationToken ct)
+    {
+        const string sql = """
+            SELECT n.nspname AS schema, s.relname AS name,
+                   seq.seqtypid::regtype AS data_type,
+                   seq.seqstart, seq.seqincrement, seq.seqmin, seq.seqmax, seq.seqcycle,
+                   dep_n.nspname || '.' || dep_t.relname || '.' || a.attname AS owned_by
+            FROM pg_class s
+            JOIN pg_namespace n ON s.relnamespace = n.oid
+            JOIN pg_sequence seq ON seq.seqrelid = s.oid
+            LEFT JOIN pg_depend d ON d.objid = s.oid AND d.deptype = 'a'
+            LEFT JOIN pg_class dep_t ON d.refobjid = dep_t.oid
+            LEFT JOIN pg_namespace dep_n ON dep_t.relnamespace = dep_n.oid
+            LEFT JOIN pg_attribute a ON a.attrelid = d.refobjid AND a.attnum = d.refobjsubid
+            WHERE s.relkind = 'S'
+              AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+            """;
+
+        var sequences = new List<PgSequenceDefinition>();
+        await using var cmd = new NpgsqlCommand(sql, connection);
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+
+        while (await reader.ReadAsync(ct))
+        {
+            sequences.Add(new PgSequenceDefinition
+            {
+                Schema = reader.GetString(0),
+                Name = reader.GetString(1),
+                DataType = reader.GetString(2),
+                StartValue = reader.GetInt64(3),
+                IncrementBy = reader.GetInt64(4),
+                MinValue = reader.IsDBNull(5) ? null : reader.GetInt64(5),
+                MaxValue = reader.IsDBNull(6) ? null : reader.GetInt64(6),
+                IsCyclic = reader.GetBoolean(7),
+                OwnedBy = reader.IsDBNull(8) ? null : reader.GetString(8)
+            });
+        }
+
+        return sequences;
+    }
+
+    internal static async Task<List<PgViewDefinition>> ReadViewsAsync(
+        NpgsqlConnection connection, CancellationToken ct)
+    {
+        const string sql = """
+            SELECT schemaname, viewname, definition, false AS is_materialized
+            FROM pg_views
+            WHERE schemaname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
+            UNION ALL
+            SELECT schemaname, matviewname, definition, true AS is_materialized
+            FROM pg_matviews
+            WHERE schemaname NOT IN ('pg_catalog', 'information_schema')
+            """;
+
+        var views = new List<PgViewDefinition>();
+        await using var cmd = new NpgsqlCommand(sql, connection);
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+
+        while (await reader.ReadAsync(ct))
+        {
+            views.Add(new PgViewDefinition
+            {
+                Schema = reader.GetString(0),
+                Name = reader.GetString(1),
+                Definition = reader.GetString(2),
+                IsMaterialized = reader.GetBoolean(3)
+            });
+        }
+
+        return views;
+    }
+
+    internal static async Task<List<PgFunctionDefinition>> ReadFunctionsAsync(
+        NpgsqlConnection connection, CancellationToken ct)
+    {
+        const string sql = """
+            SELECT n.nspname AS schema, p.proname AS name,
+                   pg_get_functiondef(p.oid) AS definition,
+                   l.lanname AS language,
+                   p.prokind AS kind
+            FROM pg_proc p
+            JOIN pg_namespace n ON p.pronamespace = n.oid
+            JOIN pg_language l ON p.prolang = l.oid
+            WHERE n.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
+              AND p.prokind IN ('f', 'p')
+            """;
+
+        var functions = new List<PgFunctionDefinition>();
+        await using var cmd = new NpgsqlCommand(sql, connection);
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+
+        while (await reader.ReadAsync(ct))
+        {
+            functions.Add(new PgFunctionDefinition
+            {
+                Schema = reader.GetString(0),
+                Name = reader.GetString(1),
+                Definition = reader.GetString(2),
+                Language = reader.GetString(3),
+                Kind = reader.GetString(4)
+            });
+        }
+
+        return functions;
+    }
+
+    /// <summary>
+    /// Checks whether a table is in the inclusion list.
+    /// Supports both "schema.table" and plain "table" formats.
+    /// </summary>
+    internal static bool IsObjectIncluded(string schema, string tableName, IReadOnlyList<string> includedObjects)
+    {
+        foreach (var included in includedObjects)
+        {
+            if (included.Contains('.'))
+            {
+                if (string.Equals(included, $"{schema}.{tableName}", StringComparison.OrdinalIgnoreCase))
+                    return true;
+            }
+            else
+            {
+                if (string.Equals(included, tableName, StringComparison.OrdinalIgnoreCase))
+                    return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/Scaffold.Migration/PostgreSql/PostgreSqlToPostgreSqlValidationEngine.cs
+++ b/src/Scaffold.Migration/PostgreSql/PostgreSqlToPostgreSqlValidationEngine.cs
@@ -1,0 +1,66 @@
+using Npgsql;
+using Scaffold.Core.Models;
+using Scaffold.Migration.SqlServer;
+
+namespace Scaffold.Migration.PostgreSql;
+
+/// <summary>
+/// Post-migration validation for PostgreSQL → PostgreSQL migrations.
+/// Compares row counts between source and target PostgreSQL databases.
+/// Unlike <see cref="PostgreSqlValidationEngine"/> which uses SQL Server as the source,
+/// this engine uses Npgsql for both source and target connections.
+/// </summary>
+public class PostgreSqlToPostgreSqlValidationEngine
+{
+    /// <summary>
+    /// Validates all specified tables by comparing source and target PostgreSQL row counts.
+    /// </summary>
+    /// <param name="sourceConnectionString">PostgreSQL source connection string.</param>
+    /// <param name="targetConnectionString">PostgreSQL target connection string.</param>
+    /// <param name="tableNames">Tables to validate (schema.table format).</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Summary of validation results across all tables.</returns>
+    public virtual async Task<ValidationSummary> ValidateAsync(
+        string sourceConnectionString,
+        string targetConnectionString,
+        IReadOnlyList<string> tableNames,
+        CancellationToken ct = default)
+    {
+        var results = new List<ValidationResult>();
+
+        foreach (var table in tableNames)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var sourceCount = await GetRowCountAsync(sourceConnectionString, table, ct);
+            var targetCount = await GetRowCountAsync(targetConnectionString, table, ct);
+
+            results.Add(new ValidationResult
+            {
+                TableName = table,
+                SourceRowCount = sourceCount,
+                TargetRowCount = targetCount,
+                ChecksumMatch = sourceCount == targetCount
+            });
+        }
+
+        return new ValidationSummary
+        {
+            Results = results,
+            TablesValidated = results.Count,
+            TablesPassed = results.Count(r => r.Passed),
+            TablesFailed = results.Count(r => !r.Passed),
+            AllPassed = results.TrueForAll(r => r.Passed)
+        };
+    }
+
+    private static async Task<long> GetRowCountAsync(
+        string connectionString, string tableName, CancellationToken ct)
+    {
+        var quoted = PgIdentifierHelper.QuotePgName(tableName);
+        await using var conn = new NpgsqlConnection(connectionString);
+        await conn.OpenAsync(ct);
+        await using var cmd = new NpgsqlCommand($"SELECT COUNT(*) FROM {quoted}", conn);
+        return (long)(await cmd.ExecuteScalarAsync(ct))!;
+    }
+}

--- a/src/Scaffold.Migration/PostgreSql/PostgreSqlValidationEngine.cs
+++ b/src/Scaffold.Migration/PostgreSql/PostgreSqlValidationEngine.cs
@@ -100,33 +100,11 @@ public class PostgreSqlValidationEngine
     /// Quotes a table name for SQL Server: dbo.Users → [dbo].[Users].
     /// Escapes embedded ']' characters by doubling them to prevent SQL injection.
     /// </summary>
-    internal static string QuoteSqlName(string tableName)
-    {
-        var parts = tableName.Split('.');
-        return string.Join(".", parts.Select(p =>
-        {
-            var clean = p.Trim('[', ']');
-            return $"[{clean.Replace("]", "]]")}]";
-        }));
-    }
+    internal static string QuoteSqlName(string tableName) => PgIdentifierHelper.QuoteSqlName(tableName);
 
     /// <summary>
     /// Quotes a table name for PostgreSQL: dbo.Users → "public"."Users".
     /// Maps "dbo" schema to "public". Escapes embedded double-quotes.
     /// </summary>
-    internal static string QuotePgName(string tableName)
-    {
-        var parts = tableName.Split('.');
-        if (parts.Length == 2 &&
-            parts[0].Trim('"', '[', ']').Equals("dbo", StringComparison.OrdinalIgnoreCase))
-        {
-            parts[0] = "public";
-        }
-
-        return string.Join(".", parts.Select(p =>
-        {
-            var clean = p.Trim('[', ']', '"');
-            return $"\"{clean.Replace("\"", "\"\"")}\"";
-        }));
-    }
+    internal static string QuotePgName(string tableName) => PgIdentifierHelper.QuotePgName(tableName);
 }

--- a/src/Scaffold.Migration/PostgreSql/ReplicationRetryPolicy.cs
+++ b/src/Scaffold.Migration/PostgreSql/ReplicationRetryPolicy.cs
@@ -1,0 +1,176 @@
+using Npgsql;
+
+namespace Scaffold.Migration.PostgreSql;
+
+/// <summary>
+/// Retry policy with exponential backoff and circuit breaker for PostgreSQL operations.
+/// Handles transient NpgsqlException errors (connection loss, timeout, deadlock, etc).
+/// </summary>
+public class ReplicationRetryPolicy
+{
+    private readonly int _maxRetries;
+    private readonly TimeSpan _initialDelay;
+    private readonly TimeSpan _maxDelay;
+    private readonly int _circuitBreakerThreshold;
+
+    private int _consecutiveFailures;
+    private DateTime _circuitOpenUntil = DateTime.MinValue;
+
+    public ReplicationRetryPolicy(
+        int maxRetries = 5,
+        TimeSpan? initialDelay = null,
+        TimeSpan? maxDelay = null,
+        int circuitBreakerThreshold = 10)
+    {
+        _maxRetries = maxRetries;
+        _initialDelay = initialDelay ?? TimeSpan.FromSeconds(1);
+        _maxDelay = maxDelay ?? TimeSpan.FromSeconds(60);
+        _circuitBreakerThreshold = circuitBreakerThreshold;
+    }
+
+    public int ConsecutiveFailures => _consecutiveFailures;
+    public bool IsCircuitOpen => DateTime.UtcNow < _circuitOpenUntil;
+    public int MaxRetries => _maxRetries;
+    public TimeSpan InitialDelay => _initialDelay;
+    public TimeSpan MaxDelay => _maxDelay;
+    public int CircuitBreakerThreshold => _circuitBreakerThreshold;
+
+    /// <summary>
+    /// Executes an async operation with retry and circuit breaker logic.
+    /// Retries only on transient NpgsqlException errors with exponential backoff.
+    /// </summary>
+    public async Task<T> ExecuteAsync<T>(
+        Func<CancellationToken, Task<T>> operation,
+        CancellationToken ct = default)
+    {
+        if (operation is null) throw new ArgumentNullException(nameof(operation));
+
+        for (int attempt = 0; attempt <= _maxRetries; attempt++)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            if (IsCircuitOpen)
+            {
+                throw new CircuitBreakerOpenException(
+                    $"Circuit breaker is open after {_consecutiveFailures} consecutive failures. " +
+                    $"Will retry after {_circuitOpenUntil:O}.");
+            }
+
+            try
+            {
+                var result = await operation(ct);
+                RecordSuccess();
+                return result;
+            }
+            catch (NpgsqlException ex) when (IsTransient(ex) && attempt < _maxRetries)
+            {
+                RecordFailure();
+                var delay = CalculateDelay(attempt);
+                await Task.Delay(delay, ct);
+            }
+            catch (NpgsqlException ex) when (IsTransient(ex) && attempt == _maxRetries)
+            {
+                RecordFailure();
+                throw;
+            }
+        }
+
+        throw new InvalidOperationException("Retry loop exited unexpectedly.");
+    }
+
+    /// <summary>
+    /// Executes a void async operation with retry logic.
+    /// </summary>
+    public async Task ExecuteAsync(
+        Func<CancellationToken, Task> operation,
+        CancellationToken ct = default)
+    {
+        if (operation is null) throw new ArgumentNullException(nameof(operation));
+
+        await ExecuteAsync(async token =>
+        {
+            await operation(token);
+            return true; // dummy return
+        }, ct);
+    }
+
+    /// <summary>
+    /// Determines if an NpgsqlException is transient and worth retrying.
+    /// Covers connection failures, deadlocks, resource limits, and server restarts.
+    /// </summary>
+    public static bool IsTransient(NpgsqlException ex)
+    {
+        // Connection-related inner exceptions
+        if (ex.InnerException is System.IO.IOException) return true;
+        if (ex.InnerException is System.Net.Sockets.SocketException) return true;
+
+        // PostgreSQL transient error codes
+        if (ex is PostgresException pgEx)
+        {
+            return pgEx.SqlState switch
+            {
+                "08000" => true, // connection_exception
+                "08001" => true, // sqlclient_unable_to_establish_sqlconnection
+                "08003" => true, // connection_does_not_exist
+                "08006" => true, // connection_failure
+                "40001" => true, // serialization_failure
+                "40P01" => true, // deadlock_detected
+                "53000" => true, // insufficient_resources
+                "53100" => true, // disk_full
+                "53200" => true, // out_of_memory
+                "53300" => true, // too_many_connections
+                "57P01" => true, // admin_shutdown
+                "57P02" => true, // crash_shutdown
+                "57P03" => true, // cannot_connect_now
+                _ => false
+            };
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Calculates delay with exponential backoff and jitter, capped at MaxDelay.
+    /// </summary>
+    internal TimeSpan CalculateDelay(int attempt)
+    {
+        var baseDelay = _initialDelay.TotalMilliseconds * Math.Pow(2, attempt);
+        var jitter = Random.Shared.NextDouble() * 0.3 * baseDelay; // up to +30% jitter
+        var totalMs = Math.Min(baseDelay + jitter, _maxDelay.TotalMilliseconds);
+        return TimeSpan.FromMilliseconds(totalMs);
+    }
+
+    /// <summary>
+    /// Records a successful operation, resetting consecutive failure count and circuit breaker.
+    /// </summary>
+    internal void RecordSuccess()
+    {
+        Interlocked.Exchange(ref _consecutiveFailures, 0);
+        _circuitOpenUntil = DateTime.MinValue;
+    }
+
+    /// <summary>
+    /// Records a failed operation. Opens the circuit breaker if threshold is reached.
+    /// </summary>
+    internal void RecordFailure()
+    {
+        var failures = Interlocked.Increment(ref _consecutiveFailures);
+        if (failures >= _circuitBreakerThreshold)
+        {
+            // Open circuit for exponential backoff based on failure count
+            var openDuration = TimeSpan.FromSeconds(
+                Math.Min(300, Math.Pow(2, failures - _circuitBreakerThreshold)));
+            _circuitOpenUntil = DateTime.UtcNow + openDuration;
+        }
+    }
+}
+
+/// <summary>
+/// Thrown when the circuit breaker is open and operations should not be attempted.
+/// </summary>
+public class CircuitBreakerOpenException : Exception
+{
+    public CircuitBreakerOpenException() { }
+    public CircuitBreakerOpenException(string message) : base(message) { }
+    public CircuitBreakerOpenException(string message, Exception inner) : base(message, inner) { }
+}

--- a/src/Scaffold.Migration/Shared/TopologicalSorter.cs
+++ b/src/Scaffold.Migration/Shared/TopologicalSorter.cs
@@ -1,0 +1,73 @@
+namespace Scaffold.Migration.Shared;
+
+/// <summary>
+/// Generic topological sort using Kahn's algorithm.
+/// Used for FK dependency ordering across all migration engines.
+/// </summary>
+public static class TopologicalSorter
+{
+    /// <summary>
+    /// Sorts string table names by dependencies. Parents before children.
+    /// If a cycle is detected, remaining items are appended at the end.
+    /// </summary>
+    public static List<string> Sort(
+        IReadOnlyList<string> items,
+        Dictionary<string, HashSet<string>> dependsOn)
+    {
+        var inDegree = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        foreach (var t in items) inDegree[t] = dependsOn[t].Count;
+
+        var queue = new Queue<string>(items.Where(t => inDegree[t] == 0));
+        var ordered = new List<string>(items.Count);
+
+        while (queue.Count > 0)
+        {
+            var current = queue.Dequeue();
+            ordered.Add(current);
+
+            foreach (var (child, parents) in dependsOn)
+            {
+                if (parents.Remove(current))
+                {
+                    inDegree[child]--;
+                    if (inDegree[child] == 0)
+                        queue.Enqueue(child);
+                }
+            }
+        }
+
+        // Append remaining (circular dependencies) in original order
+        foreach (var t in items)
+        {
+            if (!ordered.Contains(t))
+                ordered.Add(t);
+        }
+
+        return ordered;
+    }
+
+    /// <summary>
+    /// Sorts objects by dependencies using a key selector.
+    /// </summary>
+    public static List<T> Sort<T>(
+        IReadOnlyList<T> items,
+        Func<T, string> keySelector,
+        Func<T, IEnumerable<string>> dependencySelector)
+    {
+        var itemKeys = new HashSet<string>(items.Select(keySelector), StringComparer.OrdinalIgnoreCase);
+        var itemByKey = new Dictionary<string, T>(StringComparer.OrdinalIgnoreCase);
+        var deps = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var item in items)
+        {
+            var key = keySelector(item);
+            itemByKey[key] = item;
+            deps[key] = new HashSet<string>(
+                dependencySelector(item).Where(d => itemKeys.Contains(d) && !d.Equals(key, StringComparison.OrdinalIgnoreCase)),
+                StringComparer.OrdinalIgnoreCase);
+        }
+
+        var sortedKeys = Sort(items.Select(keySelector).ToList(), deps);
+        return sortedKeys.Select(k => itemByKey[k]).ToList();
+    }
+}

--- a/tests/Scaffold.Api.Tests/EngineFactoryTests.cs
+++ b/tests/Scaffold.Api.Tests/EngineFactoryTests.cs
@@ -4,6 +4,7 @@ using Scaffold.Assessment.PostgreSql;
 using Scaffold.Assessment.SqlServer;
 using Scaffold.Core.Enums;
 using Scaffold.Core.Interfaces;
+using Scaffold.Migration.PostgreSql;
 using Scaffold.Migration.SqlServer;
 
 namespace Scaffold.Api.Tests;
@@ -120,16 +121,49 @@ public class EngineFactoryTests
     }
 
     [Fact]
+    public void MigrationFactory_Create_PostgreSql_Returns_PostgreSqlMigrator()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddScoped<PostgreSqlSchemaExtractor>();
+        services.AddScoped<PostgreSqlDdlGenerator>();
+        services.AddScoped<PostgreSqlBulkCopier>();
+        services.AddScoped<PostgreSqlScriptExecutor>();
+        services.AddScoped<PostgreSqlToPostgreSqlValidationEngine>();
+        services.AddScoped<AzureExtensionHandler>();
+        services.AddScoped<PostgreSqlMigrator>();
+        services.AddScoped<SqlServerMigrator>();
+        var provider = services.BuildServiceProvider();
+        var factory = new MigrationEngineFactory(provider);
+
+        // Act
+        var engine = factory.Create(DatabasePlatform.PostgreSql);
+
+        // Assert
+        Assert.NotNull(engine);
+        Assert.IsType<PostgreSqlMigrator>(engine);
+        Assert.Equal("PostgreSql", engine.SourcePlatform);
+    }
+
+    [Fact]
     public void MigrationFactory_Create_Unsupported_Throws_NotSupportedException()
     {
         // Arrange
         var services = new ServiceCollection();
+        services.AddScoped<SqlServerMigrator>();
+        services.AddScoped<PostgreSqlSchemaExtractor>();
+        services.AddScoped<PostgreSqlDdlGenerator>();
+        services.AddScoped<PostgreSqlBulkCopier>();
+        services.AddScoped<PostgreSqlScriptExecutor>();
+        services.AddScoped<PostgreSqlToPostgreSqlValidationEngine>();
+        services.AddScoped<AzureExtensionHandler>();
+        services.AddScoped<PostgreSqlMigrator>();
         var provider = services.BuildServiceProvider();
         var factory = new MigrationEngineFactory(provider);
 
-        // Act & Assert
-        var ex = Assert.Throws<NotSupportedException>(() => factory.Create(DatabasePlatform.PostgreSql));
-        Assert.Contains("PostgreSql", ex.Message);
+        // Act & Assert — use an undefined enum value to test unsupported platform
+        var ex = Assert.Throws<NotSupportedException>(() => factory.Create((DatabasePlatform)99));
+        Assert.Contains("99", ex.Message);
     }
 
     [Fact]
@@ -137,6 +171,14 @@ public class EngineFactoryTests
     {
         // Arrange
         var services = new ServiceCollection();
+        services.AddScoped<SqlServerMigrator>();
+        services.AddScoped<PostgreSqlSchemaExtractor>();
+        services.AddScoped<PostgreSqlDdlGenerator>();
+        services.AddScoped<PostgreSqlBulkCopier>();
+        services.AddScoped<PostgreSqlScriptExecutor>();
+        services.AddScoped<PostgreSqlToPostgreSqlValidationEngine>();
+        services.AddScoped<AzureExtensionHandler>();
+        services.AddScoped<PostgreSqlMigrator>();
         var provider = services.BuildServiceProvider();
         var factory = new MigrationEngineFactory(provider);
 
@@ -148,10 +190,18 @@ public class EngineFactoryTests
     }
 
     [Fact]
-    public void MigrationFactory_SupportedPlatforms_Does_Not_Include_PostgreSql()
+    public void MigrationFactory_SupportedPlatforms_Includes_PostgreSql()
     {
         // Arrange
         var services = new ServiceCollection();
+        services.AddScoped<SqlServerMigrator>();
+        services.AddScoped<PostgreSqlSchemaExtractor>();
+        services.AddScoped<PostgreSqlDdlGenerator>();
+        services.AddScoped<PostgreSqlBulkCopier>();
+        services.AddScoped<PostgreSqlScriptExecutor>();
+        services.AddScoped<PostgreSqlToPostgreSqlValidationEngine>();
+        services.AddScoped<AzureExtensionHandler>();
+        services.AddScoped<PostgreSqlMigrator>();
         var provider = services.BuildServiceProvider();
         var factory = new MigrationEngineFactory(provider);
 
@@ -159,7 +209,7 @@ public class EngineFactoryTests
         var platforms = factory.SupportedPlatforms;
 
         // Assert
-        Assert.DoesNotContain(DatabasePlatform.PostgreSql, platforms);
+        Assert.Contains(DatabasePlatform.PostgreSql, platforms);
     }
 
     #endregion
@@ -182,11 +232,19 @@ public class EngineFactoryTests
     }
 
     [Theory]
-    [InlineData(DatabasePlatform.PostgreSql)]
+    [InlineData((DatabasePlatform)99)]
     public void MigrationFactory_Create_Unsupported_Message_Contains_Platform(DatabasePlatform platform)
     {
         // Arrange
         var services = new ServiceCollection();
+        services.AddScoped<SqlServerMigrator>();
+        services.AddScoped<PostgreSqlSchemaExtractor>();
+        services.AddScoped<PostgreSqlDdlGenerator>();
+        services.AddScoped<PostgreSqlBulkCopier>();
+        services.AddScoped<PostgreSqlScriptExecutor>();
+        services.AddScoped<PostgreSqlToPostgreSqlValidationEngine>();
+        services.AddScoped<AzureExtensionHandler>();
+        services.AddScoped<PostgreSqlMigrator>();
         var provider = services.BuildServiceProvider();
         var factory = new MigrationEngineFactory(provider);
 

--- a/tests/Scaffold.Api.Tests/MigrationCancellationServiceTests.cs
+++ b/tests/Scaffold.Api.Tests/MigrationCancellationServiceTests.cs
@@ -1,0 +1,150 @@
+using Scaffold.Api.Services;
+
+namespace Scaffold.Api.Tests;
+
+public class MigrationCancellationServiceTests
+{
+    [Fact]
+    public void Register_ReturnsCancellationToken_NotCancelled()
+    {
+        var service = new MigrationCancellationService();
+        var migrationId = Guid.NewGuid();
+
+        var token = service.Register(migrationId);
+
+        Assert.False(token.IsCancellationRequested);
+    }
+
+    [Fact]
+    public void Cancel_RegisteredMigration_ReturnsTrueAndCancelsToken()
+    {
+        var service = new MigrationCancellationService();
+        var migrationId = Guid.NewGuid();
+        var token = service.Register(migrationId);
+
+        var result = service.Cancel(migrationId);
+
+        Assert.True(result);
+        Assert.True(token.IsCancellationRequested);
+    }
+
+    [Fact]
+    public void Cancel_UnregisteredMigration_ReturnsFalse()
+    {
+        var service = new MigrationCancellationService();
+        var migrationId = Guid.NewGuid();
+
+        var result = service.Cancel(migrationId);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void Cancel_AlreadyCancelled_ReturnsFalseOnSecondCall()
+    {
+        var service = new MigrationCancellationService();
+        var migrationId = Guid.NewGuid();
+        service.Register(migrationId);
+
+        var first = service.Cancel(migrationId);
+        var second = service.Cancel(migrationId);
+
+        Assert.True(first);
+        Assert.False(second);
+    }
+
+    [Fact]
+    public void Unregister_RemovesMigration()
+    {
+        var service = new MigrationCancellationService();
+        var migrationId = Guid.NewGuid();
+        service.Register(migrationId);
+
+        service.Unregister(migrationId);
+
+        Assert.False(service.IsActive(migrationId));
+    }
+
+    [Fact]
+    public void Unregister_NonExistentMigration_DoesNotThrow()
+    {
+        var service = new MigrationCancellationService();
+
+        // Should not throw
+        service.Unregister(Guid.NewGuid());
+    }
+
+    [Fact]
+    public void IsActive_ReturnsTrueForRegistered()
+    {
+        var service = new MigrationCancellationService();
+        var migrationId = Guid.NewGuid();
+        service.Register(migrationId);
+
+        Assert.True(service.IsActive(migrationId));
+    }
+
+    [Fact]
+    public void IsActive_ReturnsFalseForUnregistered()
+    {
+        var service = new MigrationCancellationService();
+
+        Assert.False(service.IsActive(Guid.NewGuid()));
+    }
+
+    [Fact]
+    public void Cancel_DisposesTokenSource_SubsequentUnregisterSafe()
+    {
+        var service = new MigrationCancellationService();
+        var migrationId = Guid.NewGuid();
+        service.Register(migrationId);
+
+        // Cancel should dispose the token source
+        service.Cancel(migrationId);
+
+        // IsActive should be false after cancel (token removed)
+        Assert.False(service.IsActive(migrationId));
+
+        // Unregister should be safe even after cancel disposed the source
+        service.Unregister(migrationId);
+    }
+
+    [Fact]
+    public async Task ThreadSafety_ConcurrentRegisterAndCancel()
+    {
+        var service = new MigrationCancellationService();
+        var ids = Enumerable.Range(0, 100).Select(_ => Guid.NewGuid()).ToList();
+
+        // Register all concurrently
+        await Task.WhenAll(ids.Select(id => Task.Run(() => service.Register(id))));
+
+        // All should be active
+        Assert.All(ids, id => Assert.True(service.IsActive(id)));
+
+        // Cancel all concurrently
+        var results = new bool[ids.Count];
+        await Task.WhenAll(ids.Select((id, i) => Task.Run(() => results[i] = service.Cancel(id))));
+
+        // All cancellations should succeed
+        Assert.All(results, r => Assert.True(r));
+
+        // None should be active after cancellation
+        Assert.All(ids, id => Assert.False(service.IsActive(id)));
+    }
+
+    [Fact]
+    public void Register_OverwritesPreviousRegistration()
+    {
+        var service = new MigrationCancellationService();
+        var migrationId = Guid.NewGuid();
+
+        var token1 = service.Register(migrationId);
+        var token2 = service.Register(migrationId);
+
+        // The second registration should produce a different token
+        // First token may or may not be cancelled depending on implementation,
+        // but the service should be active with the new token
+        Assert.True(service.IsActive(migrationId));
+        Assert.False(token2.IsCancellationRequested);
+    }
+}

--- a/tests/Scaffold.Api.Tests/MigrationControllerCancelTests.cs
+++ b/tests/Scaffold.Api.Tests/MigrationControllerCancelTests.cs
@@ -1,0 +1,147 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.DependencyInjection;
+using Scaffold.Api.Services;
+using Scaffold.Api.Tests.Infrastructure;
+using Scaffold.Core.Enums;
+using Scaffold.Core.Models;
+using Scaffold.Infrastructure.Data;
+
+namespace Scaffold.Api.Tests;
+
+public class MigrationControllerCancelTests : IClassFixture<CustomWebApplicationFactory>
+{
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    private readonly CustomWebApplicationFactory _factory;
+    private readonly HttpClient _client;
+
+    public MigrationControllerCancelTests(CustomWebApplicationFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task Cancel_WhenMigrationIsNotRunning_Returns400()
+    {
+        var projectId = Guid.NewGuid();
+        var planId = Guid.NewGuid();
+        var migrationId = Guid.NewGuid();
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ScaffoldDbContext>();
+            var project = new MigrationProject
+            {
+                Id = projectId,
+                Name = "Cancel Not Running Test",
+                CreatedBy = "test",
+                Status = ProjectStatus.MigrationComplete,
+                MigrationPlan = new MigrationPlan
+                {
+                    Id = planId,
+                    ProjectId = projectId,
+                    Strategy = MigrationStrategy.Cutover,
+                    Status = MigrationStatus.Completed, // Not running
+                    MigrationId = migrationId,
+                    SourceConnectionString = "Server=source;",
+                    ExistingTargetConnectionString = "Server=target;"
+                }
+            };
+            db.MigrationProjects.Add(project);
+            await db.SaveChangesAsync();
+        }
+
+        var response = await _client.PostAsync(
+            $"/api/projects/{projectId}/migrations/{migrationId}/cancel", null);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("Only running migrations", body);
+    }
+
+    [Fact]
+    public async Task Cancel_WhenMigrationIdDoesNotMatch_Returns400()
+    {
+        var projectId = Guid.NewGuid();
+        var planId = Guid.NewGuid();
+        var actualMigrationId = Guid.NewGuid();
+        var wrongMigrationId = Guid.NewGuid();
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ScaffoldDbContext>();
+            var project = new MigrationProject
+            {
+                Id = projectId,
+                Name = "Cancel Wrong ID Test",
+                CreatedBy = "test",
+                Status = ProjectStatus.Migrating,
+                MigrationPlan = new MigrationPlan
+                {
+                    Id = planId,
+                    ProjectId = projectId,
+                    Strategy = MigrationStrategy.Cutover,
+                    Status = MigrationStatus.Running,
+                    MigrationId = actualMigrationId,
+                    SourceConnectionString = "Server=source;",
+                    ExistingTargetConnectionString = "Server=target;"
+                }
+            };
+            db.MigrationProjects.Add(project);
+            await db.SaveChangesAsync();
+        }
+
+        var response = await _client.PostAsync(
+            $"/api/projects/{projectId}/migrations/{wrongMigrationId}/cancel", null);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("does not match", body);
+    }
+
+    [Fact]
+    public async Task Cancel_WhenProjectNotFound_Returns404()
+    {
+        var nonExistentProjectId = Guid.NewGuid();
+        var migrationId = Guid.NewGuid();
+
+        var response = await _client.PostAsync(
+            $"/api/projects/{nonExistentProjectId}/migrations/{migrationId}/cancel", null);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Cancel_WhenNoPlan_Returns404()
+    {
+        var projectId = Guid.NewGuid();
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ScaffoldDbContext>();
+            var project = new MigrationProject
+            {
+                Id = projectId,
+                Name = "Cancel No Plan Test",
+                CreatedBy = "test",
+                Status = ProjectStatus.Created,
+                MigrationPlan = null
+            };
+            db.MigrationProjects.Add(project);
+            await db.SaveChangesAsync();
+        }
+
+        var response = await _client.PostAsync(
+            $"/api/projects/{projectId}/migrations/{Guid.NewGuid()}/cancel", null);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+}

--- a/tests/Scaffold.Integration.Tests/PostgreSqlMigrationCollection.cs
+++ b/tests/Scaffold.Integration.Tests/PostgreSqlMigrationCollection.cs
@@ -1,0 +1,11 @@
+namespace Scaffold.Integration.Tests;
+
+/// <summary>
+/// Defines a shared collection fixture so that PostgreSqlMigrationFixture is created once
+/// and shared across all test classes in the "PostgreSqlMigration" collection.
+/// The fixture seeds the PG source, creates a PG target, and runs the migration once.
+/// </summary>
+[CollectionDefinition("PostgreSqlMigration")]
+public class PostgreSqlMigrationCollection : ICollectionFixture<PostgreSqlMigrationFixture>
+{
+}

--- a/tests/Scaffold.Integration.Tests/PostgreSqlMigrationFixture.cs
+++ b/tests/Scaffold.Integration.Tests/PostgreSqlMigrationFixture.cs
@@ -1,0 +1,204 @@
+using Npgsql;
+using Scaffold.Core.Enums;
+using Scaffold.Core.Interfaces;
+using Scaffold.Core.Models;
+using Scaffold.Migration.PostgreSql;
+
+namespace Scaffold.Integration.Tests;
+
+/// <summary>
+/// Fixture for PostgreSQL → PostgreSQL migration integration tests.
+/// Reuses the seeded <c>scaffold_test</c> source database, creates an empty
+/// <c>scaffold_migration_pg_target</c> target, and runs the full PG→PG cutover
+/// migration once. Each test verifies a different aspect of the result.
+/// </summary>
+public class PostgreSqlMigrationFixture : IAsyncLifetime
+{
+    private const string PgEnvVar = "SCAFFOLD_TEST_PG_CONNECTION_STRING";
+    private const string SourceDbName = "scaffold_test";
+    private const string TargetDbName = "scaffold_migration_pg_target";
+
+    private static readonly string DefaultSourceConnectionString =
+        $"Host=localhost;Port=5432;Database={SourceDbName};Username=postgres;Password=ScaffoldTest2025!";
+
+    /// <summary>
+    /// Source PG tables included in the migration (from postgres-seed.sql).
+    /// </summary>
+    public static readonly IReadOnlyList<string> MigratedTables = new[]
+    {
+        "inventory.products",
+        "inventory.categories",
+        "inventory.product_categories"
+    };
+
+    public string SourceConnectionString { get; }
+    public string TargetConnectionString { get; private set; } = string.Empty;
+    public MigrationResult? MigrationResult { get; private set; }
+    public List<MigrationProgress> ProgressReports { get; } = new();
+
+    public PostgreSqlMigrationFixture()
+    {
+        var env = Environment.GetEnvironmentVariable(PgEnvVar);
+        if (!string.IsNullOrEmpty(env))
+        {
+            var builder = new NpgsqlConnectionStringBuilder(env) { Database = SourceDbName };
+            SourceConnectionString = builder.ConnectionString;
+        }
+        else
+        {
+            SourceConnectionString = DefaultSourceConnectionString;
+        }
+    }
+
+    public async Task InitializeAsync()
+    {
+        // Ensure source DB exists and is seeded (PostgreSqlFixture may have done this already)
+        await SeedSourceAsync();
+
+        // Create empty target database
+        await CreateTargetDatabaseAsync();
+
+        // Run the full PG→PG cutover migration
+        await RunMigrationAsync();
+    }
+
+    private async Task SeedSourceAsync()
+    {
+        // Connect to postgres admin DB to ensure source database exists
+        var builder = new NpgsqlConnectionStringBuilder(SourceConnectionString) { Database = "postgres" };
+        await using var adminConn = new NpgsqlConnection(builder.ConnectionString);
+        await adminConn.OpenAsync();
+
+        await using var checkCmd = new NpgsqlCommand(
+            $"SELECT 1 FROM pg_database WHERE datname = '{SourceDbName}'", adminConn);
+        var exists = await checkCmd.ExecuteScalarAsync();
+        if (exists == null)
+        {
+            await using var createCmd = new NpgsqlCommand($"CREATE DATABASE \"{SourceDbName}\"", adminConn);
+            await createCmd.ExecuteNonQueryAsync();
+        }
+        await adminConn.CloseAsync();
+
+        // Only seed if not already seeded (the seed SQL is not idempotent for table creation)
+        await using var conn = new NpgsqlConnection(SourceConnectionString);
+        await conn.OpenAsync();
+
+        await using var seedCheck = new NpgsqlCommand(
+            "SELECT 1 FROM information_schema.tables WHERE table_schema = 'inventory' AND table_name = 'products'",
+            conn);
+        var alreadySeeded = await seedCheck.ExecuteScalarAsync();
+        if (alreadySeeded != null) return;
+
+        var seedPath = Path.Combine(AppContext.BaseDirectory, "postgres-seed.sql");
+        if (File.Exists(seedPath))
+        {
+            var sql = await File.ReadAllTextAsync(seedPath);
+            await using var cmd = new NpgsqlCommand(sql, conn);
+            cmd.CommandTimeout = 60;
+            await cmd.ExecuteNonQueryAsync();
+        }
+    }
+
+    private async Task CreateTargetDatabaseAsync()
+    {
+        var builder = new NpgsqlConnectionStringBuilder(SourceConnectionString) { Database = "postgres" };
+        await using var adminConn = new NpgsqlConnection(builder.ConnectionString);
+        await adminConn.OpenAsync();
+
+        // Terminate existing connections for clean state
+        await using (var terminateCmd = new NpgsqlCommand(
+            $"SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '{TargetDbName}' AND pid <> pg_backend_pid()",
+            adminConn))
+        {
+            await terminateCmd.ExecuteNonQueryAsync();
+        }
+
+        // Drop if exists for clean state
+        await using (var dropCmd = new NpgsqlCommand(
+            $"DROP DATABASE IF EXISTS \"{TargetDbName}\"", adminConn))
+        {
+            await dropCmd.ExecuteNonQueryAsync();
+        }
+
+        await using var createCmd = new NpgsqlCommand($"CREATE DATABASE \"{TargetDbName}\"", adminConn);
+        await createCmd.ExecuteNonQueryAsync();
+        await adminConn.CloseAsync();
+
+        var targetBuilder = new NpgsqlConnectionStringBuilder(SourceConnectionString) { Database = TargetDbName };
+        TargetConnectionString = targetBuilder.ConnectionString;
+    }
+
+    private async Task RunMigrationAsync()
+    {
+        var plan = new MigrationPlan
+        {
+            Id = Guid.NewGuid(),
+            ProjectId = Guid.NewGuid(),
+            SourcePlatform = DatabasePlatform.PostgreSql,
+            TargetPlatform = DatabasePlatform.PostgreSql,
+            Strategy = MigrationStrategy.Cutover,
+            SourceConnectionString = SourceConnectionString,
+            UseExistingTarget = true,
+            ExistingTargetConnectionString = TargetConnectionString,
+            IncludedObjects = MigratedTables.ToList()
+        };
+
+        // Use synchronous progress reporter to avoid race conditions
+        // with Progress<T>'s async thread pool callbacks
+        var progress = new SynchronousProgress(ProgressReports);
+
+        var schemaExtractor = new PostgreSqlSchemaExtractor();
+        var ddlGenerator = new PostgreSqlDdlGenerator();
+        var bulkCopier = new PostgreSqlBulkCopier();
+        var scriptExecutor = new PostgreSqlScriptExecutor();
+        var validationEngine = new PostgreSqlToPostgreSqlValidationEngine();
+        var extensionHandler = new AzureExtensionHandler();
+
+        var migrator = new PostgreSqlMigrator(
+            schemaExtractor, ddlGenerator, bulkCopier,
+            scriptExecutor, validationEngine, extensionHandler);
+
+        MigrationResult = await migrator.ExecuteCutoverAsync(plan, progress);
+    }
+
+    public async Task DisposeAsync()
+    {
+        try
+        {
+            if (string.IsNullOrEmpty(TargetConnectionString)) return;
+
+            var builder = new NpgsqlConnectionStringBuilder(SourceConnectionString) { Database = "postgres" };
+            await using var adminConn = new NpgsqlConnection(builder.ConnectionString);
+            await adminConn.OpenAsync();
+
+            await using var terminateCmd = new NpgsqlCommand(
+                $"SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '{TargetDbName}' AND pid <> pg_backend_pid()",
+                adminConn);
+            await terminateCmd.ExecuteNonQueryAsync();
+
+            await using var dropCmd = new NpgsqlCommand(
+                $"DROP DATABASE IF EXISTS \"{TargetDbName}\"", adminConn);
+            await dropCmd.ExecuteNonQueryAsync();
+        }
+        catch
+        {
+            // Best-effort cleanup; CI containers are ephemeral anyway
+        }
+    }
+
+    /// <summary>
+    /// Synchronous IProgress implementation that adds reports immediately
+    /// instead of posting to the SynchronizationContext like Progress&lt;T&gt; does.
+    /// This ensures all reports are captured before InitializeAsync returns.
+    /// </summary>
+    private sealed class SynchronousProgress : IProgress<MigrationProgress>
+    {
+        private readonly List<MigrationProgress> _reports;
+
+        public SynchronousProgress(List<MigrationProgress> reports)
+            => _reports = reports;
+
+        public void Report(MigrationProgress value)
+            => _reports.Add(value);
+    }
+}

--- a/tests/Scaffold.Integration.Tests/PostgreSqlMigrationIntegrationTests.cs
+++ b/tests/Scaffold.Integration.Tests/PostgreSqlMigrationIntegrationTests.cs
@@ -1,0 +1,229 @@
+using Npgsql;
+using Scaffold.Migration.PostgreSql;
+
+namespace Scaffold.Integration.Tests;
+
+/// <summary>
+/// Integration tests that verify end-to-end PostgreSQL → PostgreSQL migration.
+/// All tests share a single migration run via <see cref="PostgreSqlMigrationFixture"/>;
+/// the fixture seeds the PG source, creates an empty PG target, and executes the
+/// full cutover migration once. Each test verifies a different aspect of the result.
+/// </summary>
+/// <remarks>
+/// TODO: Add logical replication integration tests once CI supports wal_level=logical.
+/// The standard PG 16 container uses wal_level=replica, so continuous sync tests
+/// that use <see cref="LogicalReplicationSyncEngine"/> are deferred to a future wave.
+/// </remarks>
+[Collection("PostgreSqlMigration")]
+public class PostgreSqlMigrationIntegrationTests
+{
+    private readonly PostgreSqlMigrationFixture _fixture;
+
+    public PostgreSqlMigrationIntegrationTests(PostgreSqlMigrationFixture fixture)
+        => _fixture = fixture;
+
+    [Fact]
+    public void MigrationResult_IsNotNull()
+        => Assert.NotNull(_fixture.MigrationResult);
+
+    [Fact]
+    public void MigrationResult_IsSuccessful()
+    {
+        var result = _fixture.MigrationResult;
+        Assert.NotNull(result);
+        Assert.True(result.Success,
+            $"Migration failed with errors: {string.Join("; ", result.Errors)}");
+    }
+
+    [Fact]
+    public void MigrationResult_HasRowsMigrated()
+    {
+        var result = _fixture.MigrationResult;
+        Assert.NotNull(result);
+        Assert.True(result.RowsMigrated > 0,
+            $"Expected rows migrated > 0, got {result.RowsMigrated}");
+    }
+
+    [Fact]
+    public void MigrationResult_HasValidations()
+    {
+        var result = _fixture.MigrationResult;
+        Assert.NotNull(result);
+        Assert.NotEmpty(result.Validations);
+    }
+
+    [Fact]
+    public void MigrationResult_AllValidationsPassed()
+    {
+        var result = _fixture.MigrationResult;
+        Assert.NotNull(result);
+        Assert.All(result.Validations, v =>
+            Assert.True(v.Passed,
+                $"Validation failed for {v.TableName}: source={v.SourceRowCount}, target={v.TargetRowCount}"));
+    }
+
+    [Fact]
+    public void MigrationResult_HasCompletionTimestamp()
+    {
+        var result = _fixture.MigrationResult;
+        Assert.NotNull(result);
+        Assert.NotNull(result.CompletedAt);
+    }
+
+    [Fact]
+    public void ProgressReports_ContainExpectedPhases()
+    {
+        var phases = _fixture.ProgressReports.Select(p => p.Phase).Distinct().ToList();
+
+        // These phases are emitted by PostgreSqlMigrator.ExecuteCutoverAsync
+        Assert.Contains("Extensions", phases);
+        Assert.Contains("SchemaExtraction", phases);
+        Assert.Contains("SchemaDeployment", phases);
+        Assert.Contains("DataMigration", phases);
+        Assert.Contains("SequenceReset", phases);
+        Assert.Contains("Validation", phases);
+    }
+
+    [Theory]
+    [InlineData("inventory.products")]
+    [InlineData("inventory.categories")]
+    [InlineData("inventory.product_categories")]
+    public async Task TargetTable_HasSameRowCountAsSource(string tableName)
+    {
+        var sourceCount = await GetRowCountAsync(_fixture.SourceConnectionString, tableName);
+        var targetCount = await GetRowCountAsync(_fixture.TargetConnectionString, tableName);
+
+        Assert.Equal(sourceCount, targetCount);
+    }
+
+    [Fact]
+    public async Task TargetProducts_HaveCorrectData()
+    {
+        // Verify actual data values, not just row counts
+        await using var conn = new NpgsqlConnection(_fixture.TargetConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = new NpgsqlCommand(
+            "SELECT name FROM inventory.products ORDER BY name", conn);
+
+        var names = new List<string>();
+        await using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            names.Add(reader.GetString(0));
+        }
+
+        Assert.Equal(3, names.Count);
+        Assert.Contains("Developer Laptop", names);
+        Assert.Contains("USB-C Hub", names);
+        Assert.Contains("Mechanical Keyboard", names);
+    }
+
+    [Fact]
+    public async Task TargetProducts_PreserveJsonbMetadata()
+    {
+        // Verify JSONB data survived the migration
+        await using var conn = new NpgsqlConnection(_fixture.TargetConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = new NpgsqlCommand(
+            "SELECT metadata->>'cpu' FROM inventory.products WHERE name = 'Developer Laptop'", conn);
+
+        var cpu = (string?)(await cmd.ExecuteScalarAsync());
+        Assert.Equal("i7", cpu);
+    }
+
+    [Fact]
+    public async Task TargetProducts_PreserveNumericPrecision()
+    {
+        // Verify NUMERIC(10,2) precision is preserved
+        await using var conn = new NpgsqlConnection(_fixture.TargetConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = new NpgsqlCommand(
+            "SELECT price FROM inventory.products WHERE name = 'Developer Laptop'", conn);
+
+        var price = (decimal)(await cmd.ExecuteScalarAsync())!;
+        Assert.Equal(1299.99m, price);
+    }
+
+    [Fact]
+    public async Task TargetCategories_HaveForeignKeyRelationships()
+    {
+        // Verify FK self-references are intact (categories with parent_id)
+        await using var conn = new NpgsqlConnection(_fixture.TargetConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = new NpgsqlCommand(
+            "SELECT COUNT(*) FROM inventory.categories WHERE parent_id IS NOT NULL", conn);
+
+        var count = (long)(await cmd.ExecuteScalarAsync())!;
+        Assert.True(count > 0, "Expected categories with parent_id references");
+    }
+
+    [Fact]
+    public async Task TargetCategories_PreserveHstoreData()
+    {
+        // Verify hstore column data survived migration
+        await using var conn = new NpgsqlConnection(_fixture.TargetConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = new NpgsqlCommand(
+            "SELECT attributes->'brand' FROM inventory.categories WHERE name = 'Electronics'", conn);
+
+        var brand = (string?)(await cmd.ExecuteScalarAsync());
+        Assert.NotNull(brand);
+        Assert.Equal("Various", brand);
+    }
+
+    [Fact]
+    public async Task TargetSequences_AreReset()
+    {
+        // Verify serial sequences are at or above the max seeded value
+        await using var conn = new NpgsqlConnection(_fixture.TargetConnectionString);
+        await conn.OpenAsync();
+
+        // Check categories serial sequence (seeded 3 categories, so seq should be >= 3)
+        await using var cmd = new NpgsqlCommand(@"
+            SELECT last_value FROM pg_sequences
+            WHERE schemaname = 'inventory' AND sequencename LIKE 'categories_id_seq%'
+            LIMIT 1", conn);
+
+        var result = await cmd.ExecuteScalarAsync();
+        if (result != null && result != DBNull.Value)
+        {
+            var lastValue = (long)result;
+            Assert.True(lastValue >= 1, $"Sequence should be reset to at least 1, got {lastValue}");
+        }
+    }
+
+    [Fact]
+    public async Task TargetSchema_HasForeignKeyConstraints()
+    {
+        // Verify FK constraints were created on the target
+        await using var conn = new NpgsqlConnection(_fixture.TargetConnectionString);
+        await conn.OpenAsync();
+
+        await using var cmd = new NpgsqlCommand("""
+            SELECT COUNT(*)
+            FROM pg_constraint con
+            JOIN pg_class rel ON con.conrelid = rel.oid
+            JOIN pg_namespace nsp ON rel.relnamespace = nsp.oid
+            WHERE con.contype = 'f'
+              AND nsp.nspname = 'inventory'
+            """, conn);
+
+        var fkCount = (long)(await cmd.ExecuteScalarAsync())!;
+        // product_categories has 2 FKs (product_id, category_id), categories has 1 FK (parent_id)
+        Assert.True(fkCount >= 3,
+            $"Expected at least 3 foreign keys in inventory schema, found {fkCount}");
+    }
+
+    #region Helpers
+
+    private static async Task<long> GetRowCountAsync(string connectionString, string tableName)
+    {
+        var quoted = PgIdentifierHelper.QuotePgName(tableName);
+        await using var conn = new NpgsqlConnection(connectionString);
+        await conn.OpenAsync();
+        await using var cmd = new NpgsqlCommand($"SELECT COUNT(*) FROM {quoted}", conn);
+        return (long)(await cmd.ExecuteScalarAsync())!;
+    }
+
+    #endregion
+}

--- a/tests/Scaffold.Integration.Tests/PostgreSqlSchemaExtractorIntegrationTests.cs
+++ b/tests/Scaffold.Integration.Tests/PostgreSqlSchemaExtractorIntegrationTests.cs
@@ -1,0 +1,164 @@
+using Scaffold.Migration.PostgreSql;
+
+namespace Scaffold.Integration.Tests;
+
+/// <summary>
+/// Integration tests for <see cref="PostgreSqlSchemaExtractor"/> against a real PostgreSQL instance.
+/// Validates that the extractor correctly reads tables, columns, indexes, sequences,
+/// views, functions, and extensions from pg_catalog and information_schema.
+/// </summary>
+[Collection("PostgreSql")]
+public class PostgreSqlSchemaExtractorIntegrationTests
+{
+    private readonly PostgreSqlFixture _fixture;
+
+    public PostgreSqlSchemaExtractorIntegrationTests(PostgreSqlFixture fixture)
+        => _fixture = fixture;
+
+    [Fact]
+    public async Task ExtractSchema_ReturnsTables()
+    {
+        var extractor = new PostgreSqlSchemaExtractor();
+        var snapshot = await extractor.ExtractSchemaAsync(_fixture.ConnectionString);
+
+        Assert.NotEmpty(snapshot.Tables);
+        // The seed creates at least: inventory.products, inventory.categories, inventory.product_categories
+        Assert.True(snapshot.Tables.Count >= 3,
+            $"Expected at least 3 tables, got {snapshot.Tables.Count}");
+    }
+
+    [Fact]
+    public async Task ExtractSchema_ReturnsIndexes()
+    {
+        var extractor = new PostgreSqlSchemaExtractor();
+        var snapshot = await extractor.ExtractSchemaAsync(_fixture.ConnectionString);
+
+        // Indexes live on tables, not at the snapshot root
+        var allIndexes = snapshot.Tables.SelectMany(t => t.Indexes).ToList();
+        Assert.NotEmpty(allIndexes);
+    }
+
+    [Fact]
+    public async Task ExtractSchema_ReturnsSequences()
+    {
+        var extractor = new PostgreSqlSchemaExtractor();
+        var snapshot = await extractor.ExtractSchemaAsync(_fixture.ConnectionString);
+
+        Assert.NotEmpty(snapshot.Sequences);
+        // The seed creates inventory.order_seq explicitly + categories_id_seq via SERIAL
+        Assert.True(snapshot.Sequences.Count >= 1,
+            $"Expected at least 1 sequence, got {snapshot.Sequences.Count}");
+    }
+
+    [Fact]
+    public async Task ExtractSchema_ReturnsViews()
+    {
+        var extractor = new PostgreSqlSchemaExtractor();
+        var snapshot = await extractor.ExtractSchemaAsync(_fixture.ConnectionString);
+
+        Assert.NotEmpty(snapshot.Views);
+        // The seed creates inventory.product_summary (regular) and analytics.daily_views (materialized)
+    }
+
+    [Fact]
+    public async Task ExtractSchema_ReturnsFunctions()
+    {
+        var extractor = new PostgreSqlSchemaExtractor();
+        var snapshot = await extractor.ExtractSchemaAsync(_fixture.ConnectionString);
+
+        Assert.NotEmpty(snapshot.Functions);
+        // The seed creates inventory.update_timestamp() trigger function
+    }
+
+    [Fact]
+    public async Task ExtractSchema_ReturnsExtensions()
+    {
+        var extractor = new PostgreSqlSchemaExtractor();
+        var snapshot = await extractor.ExtractSchemaAsync(_fixture.ConnectionString);
+
+        Assert.NotEmpty(snapshot.Extensions);
+        // The seed enables uuid-ossp, pg_trgm, and hstore
+        Assert.Contains(snapshot.Extensions, e => e == "uuid-ossp" || e == "pg_trgm" || e == "hstore");
+    }
+
+    [Fact]
+    public async Task ExtractSchema_WithTableFilter_ReturnsOnlyFilteredTables()
+    {
+        var extractor = new PostgreSqlSchemaExtractor();
+        var filter = new List<string> { "inventory.products" };
+
+        var snapshot = await extractor.ExtractSchemaAsync(_fixture.ConnectionString, filter);
+
+        Assert.Single(snapshot.Tables);
+        Assert.Equal("products", snapshot.Tables[0].TableName);
+        Assert.Equal("inventory", snapshot.Tables[0].Schema);
+    }
+
+    [Fact]
+    public async Task ExtractSchema_ProductsTable_HasExpectedColumns()
+    {
+        var extractor = new PostgreSqlSchemaExtractor();
+        var filter = new List<string> { "inventory.products" };
+
+        var snapshot = await extractor.ExtractSchemaAsync(_fixture.ConnectionString, filter);
+        var products = snapshot.Tables.First();
+
+        // PgColumnDefinition uses .Name, not .ColumnName
+        var colNames = products.Columns.Select(c => c.Name).ToList();
+        Assert.Contains("id", colNames);
+        Assert.Contains("name", colNames);
+        Assert.Contains("price", colNames);
+        Assert.Contains("metadata", colNames);
+        Assert.Contains("tags", colNames);
+        Assert.Contains("created_at", colNames);
+        Assert.Contains("updated_at", colNames);
+    }
+
+    [Fact]
+    public async Task ExtractSchema_ProductsTable_HasPrimaryKey()
+    {
+        var extractor = new PostgreSqlSchemaExtractor();
+        var filter = new List<string> { "inventory.products" };
+
+        var snapshot = await extractor.ExtractSchemaAsync(_fixture.ConnectionString, filter);
+        var products = snapshot.Tables.First();
+
+        Assert.NotNull(products.PrimaryKey);
+        Assert.Contains("id", products.PrimaryKey.Columns);
+    }
+
+    [Fact]
+    public async Task ExtractSchema_CategoriesTable_HasForeignKeys()
+    {
+        var extractor = new PostgreSqlSchemaExtractor();
+        var filter = new List<string> { "inventory.categories" };
+
+        var snapshot = await extractor.ExtractSchemaAsync(_fixture.ConnectionString, filter);
+        var categories = snapshot.Tables.First();
+
+        // categories has a self-referencing FK on parent_id
+        Assert.NotEmpty(categories.ForeignKeys);
+        Assert.Contains(categories.ForeignKeys, fk =>
+            fk.Columns.Contains("parent_id") && fk.ReferencedTable == "categories");
+    }
+
+    [Fact]
+    public async Task ExtractSchema_MultipleTables_ReturnCorrectCount()
+    {
+        var extractor = new PostgreSqlSchemaExtractor();
+        var filter = new List<string>
+        {
+            "inventory.products",
+            "inventory.categories",
+            "inventory.product_categories"
+        };
+
+        var snapshot = await extractor.ExtractSchemaAsync(_fixture.ConnectionString, filter);
+
+        Assert.Equal(3, snapshot.Tables.Count);
+        var tableNames = snapshot.Tables.Select(t => t.TableName).ToHashSet();
+        Assert.Contains("products", tableNames);
+        Assert.Contains("categories", tableNames);
+        Assert.Contains("product_categories", tableNames);
+    }
+}

--- a/tests/Scaffold.Migration.Tests/PostgreSql/AzureExtensionHandlerTests.cs
+++ b/tests/Scaffold.Migration.Tests/PostgreSql/AzureExtensionHandlerTests.cs
@@ -1,0 +1,342 @@
+using Scaffold.Migration.PostgreSql;
+using Scaffold.Migration.PostgreSql.Models;
+
+namespace Scaffold.Migration.Tests.PostgreSql;
+
+public class AzureExtensionHandlerTests
+{
+    private readonly AzureExtensionHandler _handler = new();
+
+    #region EvaluateExtensions — All Supported
+
+    [Fact]
+    public void EvaluateExtensions_AllSupported_AllInToInstall()
+    {
+        var source = new List<string> { "pgcrypto", "uuid-ossp", "citext" };
+
+        var plan = _handler.EvaluateExtensions(source);
+
+        Assert.Equal(3, plan.ToInstall.Count);
+        Assert.Empty(plan.Skipped);
+        Assert.Contains("pgcrypto", plan.ToInstall);
+        Assert.Contains("uuid-ossp", plan.ToInstall);
+        Assert.Contains("citext", plan.ToInstall);
+    }
+
+    #endregion
+
+    #region EvaluateExtensions — Unsupported
+
+    [Fact]
+    public void EvaluateExtensions_UnsupportedExtension_InSkippedWithWarning()
+    {
+        var source = new List<string> { "pgcrypto", "unsupported_ext" };
+
+        var plan = _handler.EvaluateExtensions(source);
+
+        Assert.Single(plan.Skipped);
+        Assert.Contains("unsupported_ext", plan.Skipped);
+        Assert.Contains("pgcrypto", plan.ToInstall);
+
+        var warning = plan.Warnings.First(w => w.ExtensionName == "unsupported_ext");
+        Assert.Equal(ExtensionWarningSeverity.Warning, warning.Severity);
+        Assert.Contains("not supported", warning.Message);
+    }
+
+    #endregion
+
+    #region EvaluateExtensions — SharedPreload
+
+    [Fact]
+    public void EvaluateExtensions_RequiresSharedPreload_InToInstallWithInfoWarning()
+    {
+        var source = new List<string> { "pg_stat_statements" };
+
+        var plan = _handler.EvaluateExtensions(source);
+
+        Assert.Single(plan.ToInstall);
+        Assert.Contains("pg_stat_statements", plan.ToInstall);
+        Assert.Empty(plan.Skipped);
+
+        var warning = plan.Warnings.First(w => w.ExtensionName == "pg_stat_statements");
+        Assert.Equal(ExtensionWarningSeverity.Info, warning.Severity);
+        Assert.Contains("shared_preload_libraries", warning.Message);
+    }
+
+    [Theory]
+    [InlineData("pg_cron")]
+    [InlineData("pg_hint_plan")]
+    [InlineData("pgaudit")]
+    [InlineData("pg_partman")]
+    [InlineData("timescaledb")]
+    [InlineData("pglogical")]
+    public void EvaluateExtensions_VariousPreloadExtensions_AllGetInfoWarning(string ext)
+    {
+        var plan = _handler.EvaluateExtensions([ext]);
+
+        Assert.Single(plan.ToInstall);
+        Assert.Single(plan.Warnings);
+        Assert.Equal(ExtensionWarningSeverity.Info, plan.Warnings[0].Severity);
+    }
+
+    #endregion
+
+    #region EvaluateExtensions — Dependency Ordering
+
+    [Fact]
+    public void EvaluateExtensions_PostgisTopology_PostgisFirst()
+    {
+        var source = new List<string> { "postgis_topology", "postgis" };
+
+        var plan = _handler.EvaluateExtensions(source);
+
+        Assert.Equal(2, plan.ToInstall.Count);
+        var postgisIdx = plan.ToInstall.IndexOf("postgis");
+        var topologyIdx = plan.ToInstall.IndexOf("postgis_topology");
+        Assert.True(postgisIdx < topologyIdx,
+            $"postgis (at {postgisIdx}) should come before postgis_topology (at {topologyIdx})");
+    }
+
+    [Fact]
+    public void EvaluateExtensions_PostgisTigerGeocoder_DependenciesFirst()
+    {
+        var source = new List<string> { "postgis_tiger_geocoder", "fuzzystrmatch", "postgis" };
+
+        var plan = _handler.EvaluateExtensions(source);
+
+        Assert.Equal(3, plan.ToInstall.Count);
+        var postgisIdx = plan.ToInstall.IndexOf("postgis");
+        var fuzzyIdx = plan.ToInstall.IndexOf("fuzzystrmatch");
+        var geocoderIdx = plan.ToInstall.IndexOf("postgis_tiger_geocoder");
+
+        Assert.True(postgisIdx < geocoderIdx,
+            "postgis should come before postgis_tiger_geocoder");
+        Assert.True(fuzzyIdx < geocoderIdx,
+            "fuzzystrmatch should come before postgis_tiger_geocoder");
+    }
+
+    [Fact]
+    public void EvaluateExtensions_EarthdistanceDependsOnCube_CubeFirst()
+    {
+        var source = new List<string> { "earthdistance", "cube" };
+
+        var plan = _handler.EvaluateExtensions(source);
+
+        Assert.Equal(2, plan.ToInstall.Count);
+        var cubeIdx = plan.ToInstall.IndexOf("cube");
+        var earthIdx = plan.ToInstall.IndexOf("earthdistance");
+        Assert.True(cubeIdx < earthIdx, "cube should come before earthdistance");
+    }
+
+    [Fact]
+    public void EvaluateExtensions_DependencyNotInSource_DependentStillIncluded()
+    {
+        // postgis_topology depends on postgis, but postgis not in source
+        var source = new List<string> { "postgis_topology" };
+
+        var plan = _handler.EvaluateExtensions(source);
+
+        Assert.Single(plan.ToInstall);
+        Assert.Contains("postgis_topology", plan.ToInstall);
+    }
+
+    [Fact]
+    public void EvaluateExtensions_PgroutingDependsOnPostgis_PostgisFirst()
+    {
+        var source = new List<string> { "pgrouting", "postgis" };
+
+        var plan = _handler.EvaluateExtensions(source);
+
+        var postgisIdx = plan.ToInstall.IndexOf("postgis");
+        var routingIdx = plan.ToInstall.IndexOf("pgrouting");
+        Assert.True(postgisIdx < routingIdx, "postgis should come before pgrouting");
+    }
+
+    #endregion
+
+    #region EvaluateExtensions — Mixed
+
+    [Fact]
+    public void EvaluateExtensions_MixedSupportedAndUnsupported_CorrectlySeparates()
+    {
+        var source = new List<string> { "pgcrypto", "unsupported_one", "citext", "unsupported_two" };
+
+        var plan = _handler.EvaluateExtensions(source);
+
+        Assert.Equal(2, plan.ToInstall.Count);
+        Assert.Equal(2, plan.Skipped.Count);
+        Assert.Contains("pgcrypto", plan.ToInstall);
+        Assert.Contains("citext", plan.ToInstall);
+        Assert.Contains("unsupported_one", plan.Skipped);
+        Assert.Contains("unsupported_two", plan.Skipped);
+    }
+
+    #endregion
+
+    #region EvaluateExtensions — Empty
+
+    [Fact]
+    public void EvaluateExtensions_EmptyList_ReturnsEmptyPlan()
+    {
+        var plan = _handler.EvaluateExtensions([]);
+
+        Assert.Empty(plan.ToInstall);
+        Assert.Empty(plan.Skipped);
+        Assert.Empty(plan.Warnings);
+    }
+
+    #endregion
+
+    #region OrderByDependencies
+
+    [Fact]
+    public void OrderByDependencies_NoDependencies_PreservesOrder()
+    {
+        var extensions = new List<string> { "pgcrypto", "citext", "hstore" };
+
+        var ordered = AzureExtensionHandler.OrderByDependencies(extensions);
+
+        Assert.Equal(3, ordered.Count);
+        Assert.Equal("pgcrypto", ordered[0]);
+        Assert.Equal("citext", ordered[1]);
+        Assert.Equal("hstore", ordered[2]);
+    }
+
+    [Fact]
+    public void OrderByDependencies_WithDependencyChain_DepsFirst()
+    {
+        var extensions = new List<string>
+        {
+            "postgis_raster", "postgis_topology", "postgis"
+        };
+
+        var ordered = AzureExtensionHandler.OrderByDependencies(extensions);
+
+        var postgisIdx = ordered.IndexOf("postgis");
+        var rasterIdx = ordered.IndexOf("postgis_raster");
+        var topoIdx = ordered.IndexOf("postgis_topology");
+
+        Assert.True(postgisIdx < rasterIdx, "postgis should come before postgis_raster");
+        Assert.True(postgisIdx < topoIdx, "postgis should come before postgis_topology");
+    }
+
+    [Fact]
+    public void OrderByDependencies_AddressStandard_DependencyFirst()
+    {
+        var extensions = new List<string> { "address_standardizer_data_us", "address_standardizer" };
+
+        var ordered = AzureExtensionHandler.OrderByDependencies(extensions);
+
+        Assert.Equal("address_standardizer", ordered[0]);
+        Assert.Equal("address_standardizer_data_us", ordered[1]);
+    }
+
+    [Fact]
+    public void OrderByDependencies_SingleExtension_ReturnsSame()
+    {
+        var extensions = new List<string> { "pgcrypto" };
+
+        var ordered = AzureExtensionHandler.OrderByDependencies(extensions);
+
+        Assert.Single(ordered);
+        Assert.Equal("pgcrypto", ordered[0]);
+    }
+
+    [Fact]
+    public void OrderByDependencies_Empty_ReturnsEmpty()
+    {
+        var ordered = AzureExtensionHandler.OrderByDependencies([]);
+        Assert.Empty(ordered);
+    }
+
+    [Fact]
+    public void OrderByDependencies_ComplexPostgisChain_CorrectOrder()
+    {
+        // postgis_tiger_geocoder depends on postgis + fuzzystrmatch
+        // pgrouting depends on postgis
+        var extensions = new List<string>
+        {
+            "postgis_tiger_geocoder", "pgrouting", "fuzzystrmatch", "postgis"
+        };
+
+        var ordered = AzureExtensionHandler.OrderByDependencies(extensions);
+
+        var postgisIdx = ordered.IndexOf("postgis");
+        var fuzzyIdx = ordered.IndexOf("fuzzystrmatch");
+        var geocoderIdx = ordered.IndexOf("postgis_tiger_geocoder");
+        var routingIdx = ordered.IndexOf("pgrouting");
+
+        Assert.True(postgisIdx < geocoderIdx, "postgis before postgis_tiger_geocoder");
+        Assert.True(fuzzyIdx < geocoderIdx, "fuzzystrmatch before postgis_tiger_geocoder");
+        Assert.True(postgisIdx < routingIdx, "postgis before pgrouting");
+    }
+
+    #endregion
+
+    #region ExtensionMigrationResult
+
+    [Fact]
+    public void ExtensionMigrationResult_NoFailures_SuccessIsTrue()
+    {
+        var result = new ExtensionMigrationResult
+        {
+            Installed = ["pgcrypto", "citext"],
+            Skipped = ["unsupported"],
+            Failed = []
+        };
+
+        Assert.True(result.Success);
+    }
+
+    [Fact]
+    public void ExtensionMigrationResult_WithFailures_SuccessIsFalse()
+    {
+        var result = new ExtensionMigrationResult
+        {
+            Installed = ["pgcrypto"],
+            Failed = ["citext"]
+        };
+
+        Assert.False(result.Success);
+    }
+
+    #endregion
+
+    #region EvaluateExtensions — Full Azure Supported List Spot Checks
+
+    [Theory]
+    [InlineData("pgcrypto")]
+    [InlineData("uuid-ossp")]
+    [InlineData("postgis")]
+    [InlineData("vector")]
+    [InlineData("pg_trgm")]
+    [InlineData("hstore")]
+    [InlineData("ltree")]
+    [InlineData("citext")]
+    [InlineData("btree_gin")]
+    [InlineData("postgres_fdw")]
+    public void EvaluateExtensions_KnownSupportedExtension_InToInstall(string ext)
+    {
+        var plan = _handler.EvaluateExtensions([ext]);
+
+        Assert.Single(plan.ToInstall);
+        Assert.Contains(ext, plan.ToInstall);
+        Assert.Empty(plan.Skipped);
+    }
+
+    [Theory]
+    [InlineData("pg_repack")]
+    [InlineData("tablefunc")]
+    [InlineData("unaccent")]
+    [InlineData("intarray")]
+    [InlineData("semver")]
+    public void EvaluateExtensions_MoreSupportedExtensions_InToInstall(string ext)
+    {
+        var plan = _handler.EvaluateExtensions([ext]);
+
+        Assert.Single(plan.ToInstall);
+        Assert.Empty(plan.Skipped);
+    }
+
+    #endregion
+}

--- a/tests/Scaffold.Migration.Tests/PostgreSql/LogicalReplicationSyncEngineTests.cs
+++ b/tests/Scaffold.Migration.Tests/PostgreSql/LogicalReplicationSyncEngineTests.cs
@@ -1,0 +1,318 @@
+using Moq;
+using Scaffold.Core.Interfaces;
+using Scaffold.Migration.PostgreSql;
+
+namespace Scaffold.Migration.Tests.PostgreSql;
+
+public class LogicalReplicationSyncEngineTests
+{
+    private static PostgreSqlBulkCopier CreateMockBulkCopier()
+        => new Mock<PostgreSqlBulkCopier>().Object;
+
+    #region Constructor
+
+    [Fact]
+    public void Constructor_NullBulkCopier_ThrowsArgumentNullException()
+    {
+        var ex = Assert.Throws<ArgumentNullException>(
+            () => new LogicalReplicationSyncEngine(null!));
+        Assert.Equal("bulkCopier", ex.ParamName);
+    }
+
+    [Fact]
+    public void Constructor_ValidBulkCopier_Succeeds()
+    {
+        var engine = new LogicalReplicationSyncEngine(CreateMockBulkCopier());
+
+        Assert.NotNull(engine);
+    }
+
+    [Fact]
+    public void Constructor_WithProgress_Succeeds()
+    {
+        var progress = new Progress<MigrationProgress>();
+        var engine = new LogicalReplicationSyncEngine(CreateMockBulkCopier(), progress);
+
+        Assert.NotNull(engine);
+    }
+
+    [Fact]
+    public void Constructor_WithCustomPollInterval_Succeeds()
+    {
+        var engine = new LogicalReplicationSyncEngine(
+            CreateMockBulkCopier(),
+            pollInterval: TimeSpan.FromSeconds(10));
+
+        Assert.NotNull(engine);
+    }
+
+    #endregion
+
+    #region Initial state
+
+    [Fact]
+    public void TotalRowsSynced_Initially_IsZero()
+    {
+        var engine = new LogicalReplicationSyncEngine(CreateMockBulkCopier());
+
+        Assert.Equal(0, engine.TotalRowsSynced);
+    }
+
+    [Fact]
+    public void IsRunning_Initially_IsFalse()
+    {
+        var engine = new LogicalReplicationSyncEngine(CreateMockBulkCopier());
+
+        Assert.False(engine.IsRunning);
+    }
+
+    #endregion
+
+    #region GenerateSlotName
+
+    [Fact]
+    public void GenerateSlotName_ContainsPrefix()
+    {
+        var id = Guid.NewGuid();
+        var slotName = LogicalReplicationSyncEngine.GenerateSlotName(id);
+
+        Assert.StartsWith("scaffold_", slotName);
+    }
+
+    [Fact]
+    public void GenerateSlotName_ContainsMigrationId()
+    {
+        var id = Guid.NewGuid();
+        var slotName = LogicalReplicationSyncEngine.GenerateSlotName(id);
+
+        Assert.Contains(id.ToString("N"), slotName);
+    }
+
+    [Fact]
+    public void GenerateSlotName_MaxLength63()
+    {
+        var id = Guid.NewGuid();
+        var slotName = LogicalReplicationSyncEngine.GenerateSlotName(id);
+
+        Assert.True(slotName.Length <= 63,
+            $"Slot name '{slotName}' exceeds 63 chars (length: {slotName.Length})");
+    }
+
+    [Fact]
+    public void GenerateSlotName_IsLowercase()
+    {
+        var id = Guid.NewGuid();
+        var slotName = LogicalReplicationSyncEngine.GenerateSlotName(id);
+
+        Assert.Equal(slotName, slotName.ToLowerInvariant());
+    }
+
+    [Fact]
+    public void GenerateSlotName_ContainsOnlyValidChars()
+    {
+        var id = Guid.NewGuid();
+        var slotName = LogicalReplicationSyncEngine.GenerateSlotName(id);
+
+        Assert.Matches("^[a-z0-9_]+$", slotName);
+    }
+
+    [Fact]
+    public void GenerateSlotName_DifferentIds_ProduceDifferentNames()
+    {
+        var id1 = Guid.NewGuid();
+        var id2 = Guid.NewGuid();
+
+        var name1 = LogicalReplicationSyncEngine.GenerateSlotName(id1);
+        var name2 = LogicalReplicationSyncEngine.GenerateSlotName(id2);
+
+        Assert.NotEqual(name1, name2);
+    }
+
+    [Fact]
+    public void GenerateSlotName_SameId_ProducesSameName()
+    {
+        var id = Guid.NewGuid();
+
+        var name1 = LogicalReplicationSyncEngine.GenerateSlotName(id);
+        var name2 = LogicalReplicationSyncEngine.GenerateSlotName(id);
+
+        Assert.Equal(name1, name2);
+    }
+
+    [Fact]
+    public void GenerateSlotName_EmptyGuid_ProducesValidName()
+    {
+        var slotName = LogicalReplicationSyncEngine.GenerateSlotName(Guid.Empty);
+
+        Assert.StartsWith("scaffold_", slotName);
+        Assert.Matches("^[a-z0-9_]+$", slotName);
+    }
+
+    #endregion
+
+    #region GeneratePublicationName
+
+    [Fact]
+    public void GeneratePublicationName_ContainsPrefix()
+    {
+        var id = Guid.NewGuid();
+        var pubName = LogicalReplicationSyncEngine.GeneratePublicationName(id);
+
+        Assert.StartsWith("scaffold_pub_", pubName);
+    }
+
+    [Fact]
+    public void GeneratePublicationName_MaxLength63()
+    {
+        var id = Guid.NewGuid();
+        var pubName = LogicalReplicationSyncEngine.GeneratePublicationName(id);
+
+        Assert.True(pubName.Length <= 63,
+            $"Publication name '{pubName}' exceeds 63 chars (length: {pubName.Length})");
+    }
+
+    [Fact]
+    public void GeneratePublicationName_DifferentIds_ProduceDifferentNames()
+    {
+        var id1 = Guid.NewGuid();
+        var id2 = Guid.NewGuid();
+
+        var name1 = LogicalReplicationSyncEngine.GeneratePublicationName(id1);
+        var name2 = LogicalReplicationSyncEngine.GeneratePublicationName(id2);
+
+        Assert.NotEqual(name1, name2);
+    }
+
+    [Fact]
+    public void GeneratePublicationName_SameId_ProducesSameName()
+    {
+        var id = Guid.NewGuid();
+
+        var name1 = LogicalReplicationSyncEngine.GeneratePublicationName(id);
+        var name2 = LogicalReplicationSyncEngine.GeneratePublicationName(id);
+
+        Assert.Equal(name1, name2);
+    }
+
+    #endregion
+
+    #region StartAsync validation
+
+    [Fact]
+    public async Task StartAsync_NullSourceConnection_ThrowsArgumentException()
+    {
+        var engine = new LogicalReplicationSyncEngine(CreateMockBulkCopier());
+
+        var ex = await Assert.ThrowsAsync<ArgumentException>(
+            () => engine.StartAsync(null!, "target", ["table1"], Guid.NewGuid()));
+        Assert.Equal("sourceConnectionString", ex.ParamName);
+    }
+
+    [Fact]
+    public async Task StartAsync_EmptySourceConnection_ThrowsArgumentException()
+    {
+        var engine = new LogicalReplicationSyncEngine(CreateMockBulkCopier());
+
+        var ex = await Assert.ThrowsAsync<ArgumentException>(
+            () => engine.StartAsync("", "target", ["table1"], Guid.NewGuid()));
+        Assert.Equal("sourceConnectionString", ex.ParamName);
+    }
+
+    [Fact]
+    public async Task StartAsync_WhitespaceSourceConnection_ThrowsArgumentException()
+    {
+        var engine = new LogicalReplicationSyncEngine(CreateMockBulkCopier());
+
+        var ex = await Assert.ThrowsAsync<ArgumentException>(
+            () => engine.StartAsync("   ", "target", ["table1"], Guid.NewGuid()));
+        Assert.Equal("sourceConnectionString", ex.ParamName);
+    }
+
+    [Fact]
+    public async Task StartAsync_NullTargetConnection_ThrowsArgumentException()
+    {
+        var engine = new LogicalReplicationSyncEngine(CreateMockBulkCopier());
+
+        var ex = await Assert.ThrowsAsync<ArgumentException>(
+            () => engine.StartAsync("source", null!, ["table1"], Guid.NewGuid()));
+        Assert.Equal("targetConnectionString", ex.ParamName);
+    }
+
+    [Fact]
+    public async Task StartAsync_EmptyTargetConnection_ThrowsArgumentException()
+    {
+        var engine = new LogicalReplicationSyncEngine(CreateMockBulkCopier());
+
+        var ex = await Assert.ThrowsAsync<ArgumentException>(
+            () => engine.StartAsync("source", "", ["table1"], Guid.NewGuid()));
+        Assert.Equal("targetConnectionString", ex.ParamName);
+    }
+
+    #endregion
+
+    #region CompleteCutoverAsync validation
+
+    [Fact]
+    public async Task CompleteCutoverAsync_BeforeStart_ThrowsInvalidOperationException()
+    {
+        var engine = new LogicalReplicationSyncEngine(CreateMockBulkCopier());
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => engine.CompleteCutoverAsync(Guid.NewGuid()));
+        Assert.Contains("StartAsync", ex.Message);
+    }
+
+    #endregion
+
+    #region Cancellation
+
+    [Fact]
+    public async Task StartAsync_CancelledToken_ThrowsOperationCanceledException()
+    {
+        var engine = new LogicalReplicationSyncEngine(CreateMockBulkCopier());
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        // Should throw since the engine tries to validate wal_level with a cancelled token
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => engine.StartAsync(
+                "Host=fake;Database=test;",
+                "Host=fake;Database=test;",
+                ["public.test"],
+                Guid.NewGuid(),
+                cts.Token));
+    }
+
+    #endregion
+
+    #region Name format consistency
+
+    [Theory]
+    [InlineData("00000000-0000-0000-0000-000000000000")]
+    [InlineData("12345678-1234-1234-1234-123456789abc")]
+    [InlineData("ffffffff-ffff-ffff-ffff-ffffffffffff")]
+    public void GenerateSlotName_VariousGuids_AllValid(string guidStr)
+    {
+        var id = Guid.Parse(guidStr);
+        var slotName = LogicalReplicationSyncEngine.GenerateSlotName(id);
+
+        Assert.StartsWith("scaffold_", slotName);
+        Assert.True(slotName.Length <= 63);
+        Assert.Matches("^[a-z0-9_]+$", slotName);
+    }
+
+    [Theory]
+    [InlineData("00000000-0000-0000-0000-000000000000")]
+    [InlineData("12345678-1234-1234-1234-123456789abc")]
+    [InlineData("ffffffff-ffff-ffff-ffff-ffffffffffff")]
+    public void GeneratePublicationName_VariousGuids_AllValid(string guidStr)
+    {
+        var id = Guid.Parse(guidStr);
+        var pubName = LogicalReplicationSyncEngine.GeneratePublicationName(id);
+
+        Assert.StartsWith("scaffold_pub_", pubName);
+        Assert.True(pubName.Length <= 63);
+    }
+
+    #endregion
+}

--- a/tests/Scaffold.Migration.Tests/PostgreSql/PgIdentifierHelperTests.cs
+++ b/tests/Scaffold.Migration.Tests/PostgreSql/PgIdentifierHelperTests.cs
@@ -1,0 +1,214 @@
+using Scaffold.Migration.PostgreSql;
+
+namespace Scaffold.Migration.Tests.PostgreSql;
+
+public class PgIdentifierHelperTests
+{
+    #region QuoteIdentifier
+
+    [Fact]
+    public void QuoteIdentifier_NormalName_WrapsInDoubleQuotes()
+    {
+        var result = PgIdentifierHelper.QuoteIdentifier("Users");
+        Assert.Equal("\"Users\"", result);
+    }
+
+    [Fact]
+    public void QuoteIdentifier_NameWithDoubleQuotes_EscapesEmbeddedQuotes()
+    {
+        var result = PgIdentifierHelper.QuoteIdentifier("my\"table");
+        Assert.Equal("\"my\"\"table\"", result);
+    }
+
+    [Fact]
+    public void QuoteIdentifier_EmptyString_ReturnsEmptyQuotedIdentifier()
+    {
+        var result = PgIdentifierHelper.QuoteIdentifier("");
+        Assert.Equal("\"\"", result);
+    }
+
+    [Theory]
+    [InlineData("Id", "\"Id\"")]
+    [InlineData("column_name", "\"column_name\"")]
+    [InlineData("has\"quote", "\"has\"\"quote\"")]
+    public void QuoteIdentifier_VariousInputs_ReturnsExpected(string input, string expected)
+    {
+        Assert.Equal(expected, PgIdentifierHelper.QuoteIdentifier(input));
+    }
+
+    #endregion
+
+    #region MapSchema
+
+    [Fact]
+    public void MapSchema_Dbo_ReturnsPublic()
+    {
+        Assert.Equal("public", PgIdentifierHelper.MapSchema("dbo"));
+    }
+
+    [Fact]
+    public void MapSchema_DboUpperCase_ReturnsPublic()
+    {
+        Assert.Equal("public", PgIdentifierHelper.MapSchema("DBO"));
+    }
+
+    [Fact]
+    public void MapSchema_Public_ReturnsPublic()
+    {
+        Assert.Equal("public", PgIdentifierHelper.MapSchema("public"));
+    }
+
+    [Fact]
+    public void MapSchema_CustomSchema_PreservesName()
+    {
+        Assert.Equal("custom_schema", PgIdentifierHelper.MapSchema("custom_schema"));
+    }
+
+    [Theory]
+    [InlineData("dbo", "public")]
+    [InlineData("Dbo", "public")]
+    [InlineData("DBO", "public")]
+    [InlineData("public", "public")]
+    [InlineData("sales", "sales")]
+    [InlineData("hr", "hr")]
+    public void MapSchema_VariousInputs_ReturnsExpected(string input, string expected)
+    {
+        Assert.Equal(expected, PgIdentifierHelper.MapSchema(input));
+    }
+
+    #endregion
+
+    #region QuotePgName
+
+    [Fact]
+    public void QuotePgName_DboUsers_MapsToPublicAndQuotes()
+    {
+        var result = PgIdentifierHelper.QuotePgName("dbo.Users");
+        Assert.Equal("\"public\".\"Users\"", result);
+    }
+
+    [Fact]
+    public void QuotePgName_PublicOrders_QuotesWithoutMapping()
+    {
+        var result = PgIdentifierHelper.QuotePgName("public.orders");
+        Assert.Equal("\"public\".\"orders\"", result);
+    }
+
+    [Fact]
+    public void QuotePgName_CustomSchemaWithQuotedName_StripsQuotesAndRequotes()
+    {
+        var result = PgIdentifierHelper.QuotePgName("custom.\"quoted\"");
+        Assert.Equal("\"custom\".\"quoted\"", result);
+    }
+
+    [Fact]
+    public void QuotePgName_BracketNotation_StripsBracketsAndQuotes()
+    {
+        var result = PgIdentifierHelper.QuotePgName("[dbo].[Users]");
+        Assert.Equal("\"public\".\"Users\"", result);
+    }
+
+    [Fact]
+    public void QuotePgName_SinglePartName_QuotesWithoutSchemaMapping()
+    {
+        var result = PgIdentifierHelper.QuotePgName("Users");
+        Assert.Equal("\"Users\"", result);
+    }
+
+    [Theory]
+    [InlineData("dbo.Users", "\"public\".\"Users\"")]
+    [InlineData("DBO.Orders", "\"public\".\"Orders\"")]
+    [InlineData("[dbo].[Products]", "\"public\".\"Products\"")]
+    [InlineData("sales.Invoices", "\"sales\".\"Invoices\"")]
+    public void QuotePgName_VariousInputs_ReturnsExpected(string input, string expected)
+    {
+        Assert.Equal(expected, PgIdentifierHelper.QuotePgName(input));
+    }
+
+    #endregion
+
+    #region QuoteSqlName
+
+    [Fact]
+    public void QuoteSqlName_DboUsers_WrapsBothPartsInBrackets()
+    {
+        var result = PgIdentifierHelper.QuoteSqlName("dbo.Users");
+        Assert.Equal("[dbo].[Users]", result);
+    }
+
+    [Fact]
+    public void QuoteSqlName_NameWithEmbeddedBracket_EscapesByDoubling()
+    {
+        var result = PgIdentifierHelper.QuoteSqlName("dbo.my]table");
+        Assert.Equal("[dbo].[my]]table]", result);
+    }
+
+    [Fact]
+    public void QuoteSqlName_AlreadyBracketed_StripsAndReapplies()
+    {
+        var result = PgIdentifierHelper.QuoteSqlName("[dbo].[Users]");
+        Assert.Equal("[dbo].[Users]", result);
+    }
+
+    [Theory]
+    [InlineData("dbo.Users", "[dbo].[Users]")]
+    [InlineData("schema.table", "[schema].[table]")]
+    [InlineData("single", "[single]")]
+    public void QuoteSqlName_VariousInputs_ReturnsExpected(string input, string expected)
+    {
+        Assert.Equal(expected, PgIdentifierHelper.QuoteSqlName(input));
+    }
+
+    #endregion
+
+    #region ClampTimeout
+
+    [Fact]
+    public void ClampTimeout_NullValue_UsesDefault()
+    {
+        var result = PgIdentifierHelper.ClampTimeout(null, 600);
+        Assert.Equal(600, result);
+    }
+
+    [Fact]
+    public void ClampTimeout_BelowMinimum_ClampsTo30()
+    {
+        var result = PgIdentifierHelper.ClampTimeout(5, 600);
+        Assert.Equal(30, result);
+    }
+
+    [Fact]
+    public void ClampTimeout_AboveMaximum_ClampsTo3600()
+    {
+        var result = PgIdentifierHelper.ClampTimeout(9999, 600);
+        Assert.Equal(3600, result);
+    }
+
+    [Fact]
+    public void ClampTimeout_InRange_ReturnsValue()
+    {
+        var result = PgIdentifierHelper.ClampTimeout(120, 600);
+        Assert.Equal(120, result);
+    }
+
+    [Fact]
+    public void ClampTimeout_NullWithDefaultBelowMin_ClampsTo30()
+    {
+        var result = PgIdentifierHelper.ClampTimeout(null, 10);
+        Assert.Equal(30, result);
+    }
+
+    [Theory]
+    [InlineData(null, 600, 600)]
+    [InlineData(30, 600, 30)]
+    [InlineData(3600, 600, 3600)]
+    [InlineData(29, 600, 30)]
+    [InlineData(3601, 600, 3600)]
+    [InlineData(100, 200, 100)]
+    public void ClampTimeout_VariousInputs_ReturnsExpected(int? value, int defaultValue, int expected)
+    {
+        Assert.Equal(expected, PgIdentifierHelper.ClampTimeout(value, defaultValue));
+    }
+
+    #endregion
+}

--- a/tests/Scaffold.Migration.Tests/PostgreSql/PostgreSqlBulkCopierTests.cs
+++ b/tests/Scaffold.Migration.Tests/PostgreSql/PostgreSqlBulkCopierTests.cs
@@ -1,0 +1,518 @@
+using Scaffold.Core.Interfaces;
+using Scaffold.Migration.PostgreSql;
+using Scaffold.Migration.Shared;
+
+namespace Scaffold.Migration.Tests.PostgreSql;
+
+public class PostgreSqlBulkCopierTests
+{
+    #region CopyDataAsync — empty input
+
+    [Fact]
+    public async Task CopyDataAsync_EmptyTableList_ReturnsZero()
+    {
+        var copier = new PostgreSqlBulkCopier();
+        var result = await copier.CopyDataAsync(
+            "Host=fake;Database=source",
+            "Host=fake;Database=target",
+            Array.Empty<string>());
+
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public async Task CopyDataAsync_EmptyTableList_ReportsCompletionProgress()
+    {
+        var copier = new PostgreSqlBulkCopier();
+        var reports = new List<MigrationProgress>();
+        var progress = new SynchronousProgress<MigrationProgress>(reports.Add);
+
+        await copier.CopyDataAsync(
+            "Host=fake;Database=source",
+            "Host=fake;Database=target",
+            Array.Empty<string>(),
+            progress);
+
+        Assert.Single(reports);
+        Assert.Equal("DataMigration", reports[0].Phase);
+        Assert.Equal(100, reports[0].PercentComplete);
+        Assert.Equal("No tables to migrate.", reports[0].Message);
+    }
+
+    [Fact]
+    public async Task CopyDataAsync_EmptyTableList_NullProgress_DoesNotThrow()
+    {
+        var copier = new PostgreSqlBulkCopier();
+
+        // Should not throw even with null progress
+        var result = await copier.CopyDataAsync(
+            "Host=fake;Database=source",
+            "Host=fake;Database=target",
+            Array.Empty<string>(),
+            progress: null);
+
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public async Task CopyDataAsync_EmptyTableList_WithTimeout_ReturnsZero()
+    {
+        var copier = new PostgreSqlBulkCopier();
+        var result = await copier.CopyDataAsync(
+            "Host=fake;Database=source",
+            "Host=fake;Database=target",
+            Array.Empty<string>(),
+            bulkCopyTimeout: 120);
+
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public async Task CopyDataAsync_EmptyTableList_WithCancellation_ReturnsZero()
+    {
+        var copier = new PostgreSqlBulkCopier();
+        using var cts = new CancellationTokenSource();
+
+        var result = await copier.CopyDataAsync(
+            "Host=fake;Database=source",
+            "Host=fake;Database=target",
+            Array.Empty<string>(),
+            ct: cts.Token);
+
+        Assert.Equal(0, result);
+    }
+
+    #endregion
+
+    #region BuildCopyExportCommand — COPY TO STDOUT
+
+    [Fact]
+    public void BuildCopyExportCommand_SimpleTable_GeneratesCorrectSql()
+    {
+        var result = PostgreSqlBulkCopier.BuildCopyExportCommand(
+            "public.users",
+            new[] { "id", "name", "email" });
+
+        Assert.Equal(
+            "COPY \"public\".\"users\" (\"id\", \"name\", \"email\") TO STDOUT",
+            result);
+    }
+
+    [Fact]
+    public void BuildCopyExportCommand_DboSchema_MapsToPublic()
+    {
+        var result = PostgreSqlBulkCopier.BuildCopyExportCommand(
+            "dbo.Users",
+            new[] { "Id", "UserName" });
+
+        Assert.Equal(
+            "COPY \"public\".\"Users\" (\"Id\", \"UserName\") TO STDOUT",
+            result);
+    }
+
+    [Fact]
+    public void BuildCopyExportCommand_SingleColumn_NoTrailingComma()
+    {
+        var result = PostgreSqlBulkCopier.BuildCopyExportCommand(
+            "public.config",
+            new[] { "value" });
+
+        Assert.Equal(
+            "COPY \"public\".\"config\" (\"value\") TO STDOUT",
+            result);
+    }
+
+    [Fact]
+    public void BuildCopyExportCommand_ColumnWithSpecialChars_ProperlyQuoted()
+    {
+        var result = PostgreSqlBulkCopier.BuildCopyExportCommand(
+            "public.data",
+            new[] { "normal_col", "has\"quote", "has space" });
+
+        Assert.Equal(
+            "COPY \"public\".\"data\" (\"normal_col\", \"has\"\"quote\", \"has space\") TO STDOUT",
+            result);
+    }
+
+    [Fact]
+    public void BuildCopyExportCommand_SinglePartTableName_QuotedCorrectly()
+    {
+        var result = PostgreSqlBulkCopier.BuildCopyExportCommand(
+            "users",
+            new[] { "id", "name" });
+
+        Assert.Equal(
+            "COPY \"users\" (\"id\", \"name\") TO STDOUT",
+            result);
+    }
+
+    [Fact]
+    public void BuildCopyExportCommand_BracketNotation_StrippedAndQuoted()
+    {
+        var result = PostgreSqlBulkCopier.BuildCopyExportCommand(
+            "[dbo].[Products]",
+            new[] { "ProductId", "Name" });
+
+        Assert.Equal(
+            "COPY \"public\".\"Products\" (\"ProductId\", \"Name\") TO STDOUT",
+            result);
+    }
+
+    #endregion
+
+    #region BuildCopyImportCommand — COPY FROM STDIN
+
+    [Fact]
+    public void BuildCopyImportCommand_SimpleTable_GeneratesCorrectSql()
+    {
+        var result = PostgreSqlBulkCopier.BuildCopyImportCommand(
+            "public.users",
+            new[] { "id", "name", "email" });
+
+        Assert.Equal(
+            "COPY \"public\".\"users\" (\"id\", \"name\", \"email\") FROM STDIN",
+            result);
+    }
+
+    [Fact]
+    public void BuildCopyImportCommand_DboSchema_MapsToPublic()
+    {
+        var result = PostgreSqlBulkCopier.BuildCopyImportCommand(
+            "dbo.Orders",
+            new[] { "OrderId", "CustomerId" });
+
+        Assert.Equal(
+            "COPY \"public\".\"Orders\" (\"OrderId\", \"CustomerId\") FROM STDIN",
+            result);
+    }
+
+    [Fact]
+    public void BuildCopyImportCommand_ColumnWithSpecialChars_ProperlyQuoted()
+    {
+        var result = PostgreSqlBulkCopier.BuildCopyImportCommand(
+            "public.data",
+            new[] { "col with space", "col\"with\"quotes" });
+
+        Assert.Equal(
+            "COPY \"public\".\"data\" (\"col with space\", \"col\"\"with\"\"quotes\") FROM STDIN",
+            result);
+    }
+
+    #endregion
+
+    #region BuildResetSequenceSql — sequence reset query
+
+    [Fact]
+    public void BuildResetSequenceSql_SimpleNames_GeneratesCorrectSql()
+    {
+        var result = PostgreSqlBulkCopier.BuildResetSequenceSql(
+            "public.users_id_seq",
+            "public.users",
+            "id");
+
+        Assert.Equal(
+            "SELECT setval(\"public\".\"users_id_seq\"::text::regclass, COALESCE((SELECT MAX(\"id\") FROM \"public\".\"users\"), 1), true)",
+            result);
+    }
+
+    [Fact]
+    public void BuildResetSequenceSql_CustomSchema_PreservedCorrectly()
+    {
+        var result = PostgreSqlBulkCopier.BuildResetSequenceSql(
+            "sales.orders_order_id_seq",
+            "sales.orders",
+            "order_id");
+
+        Assert.Equal(
+            "SELECT setval(\"sales\".\"orders_order_id_seq\"::text::regclass, COALESCE((SELECT MAX(\"order_id\") FROM \"sales\".\"orders\"), 1), true)",
+            result);
+    }
+
+    [Fact]
+    public void BuildResetSequenceSql_ColumnWithSpecialChars_Quoted()
+    {
+        var result = PostgreSqlBulkCopier.BuildResetSequenceSql(
+            "public.my_seq",
+            "public.my_table",
+            "my\"col");
+
+        Assert.Contains("\"my\"\"col\"", result);
+        Assert.StartsWith("SELECT setval(", result);
+        Assert.EndsWith(", true)", result);
+    }
+
+    [Fact]
+    public void BuildResetSequenceSql_ContainsCoalesceWithFallbackToOne()
+    {
+        var result = PostgreSqlBulkCopier.BuildResetSequenceSql(
+            "public.seq1",
+            "public.tbl1",
+            "col1");
+
+        // COALESCE ensures empty tables get sequence reset to 1
+        Assert.Contains("COALESCE((SELECT MAX(\"col1\") FROM \"public\".\"tbl1\"), 1)", result);
+    }
+
+    [Fact]
+    public void BuildResetSequenceSql_UsesRegclassCast()
+    {
+        var result = PostgreSqlBulkCopier.BuildResetSequenceSql(
+            "public.seq1",
+            "public.tbl1",
+            "col1");
+
+        // Must cast to regclass for setval
+        Assert.Contains("::text::regclass", result);
+    }
+
+    #endregion
+
+    #region TopologicalSorter integration — FK dependency ordering
+
+    [Fact]
+    public void TopologicalSort_NoDependencies_PreservesOrder()
+    {
+        var tables = new[] { "public.a", "public.b", "public.c" };
+        var deps = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["public.a"] = [],
+            ["public.b"] = [],
+            ["public.c"] = []
+        };
+
+        var result = TopologicalSorter.Sort(tables.ToList(), deps);
+
+        Assert.Equal(3, result.Count);
+        Assert.Contains("public.a", result);
+        Assert.Contains("public.b", result);
+        Assert.Contains("public.c", result);
+    }
+
+    [Fact]
+    public void TopologicalSort_LinearDependency_ParentBeforeChild()
+    {
+        // c → b → a
+        var tables = new[] { "public.c", "public.b", "public.a" };
+        var deps = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["public.a"] = [],
+            ["public.b"] = new(StringComparer.OrdinalIgnoreCase) { "public.a" },
+            ["public.c"] = new(StringComparer.OrdinalIgnoreCase) { "public.b" }
+        };
+
+        var result = TopologicalSorter.Sort(tables.ToList(), deps);
+
+        Assert.True(result.IndexOf("public.a") < result.IndexOf("public.b"));
+        Assert.True(result.IndexOf("public.b") < result.IndexOf("public.c"));
+    }
+
+    [Fact]
+    public void TopologicalSort_MultipleDependencies_AllParentsFirst()
+    {
+        // orders depends on users and products
+        var tables = new[] { "public.orders", "public.users", "public.products" };
+        var deps = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["public.users"] = [],
+            ["public.products"] = [],
+            ["public.orders"] = new(StringComparer.OrdinalIgnoreCase) { "public.users", "public.products" }
+        };
+
+        var result = TopologicalSorter.Sort(tables.ToList(), deps);
+
+        Assert.True(result.IndexOf("public.users") < result.IndexOf("public.orders"));
+        Assert.True(result.IndexOf("public.products") < result.IndexOf("public.orders"));
+    }
+
+    [Fact]
+    public void TopologicalSort_CircularDependency_AllTablesIncluded()
+    {
+        var tables = new[] { "public.a", "public.b", "public.c" };
+        var deps = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["public.a"] = new(StringComparer.OrdinalIgnoreCase) { "public.b" },
+            ["public.b"] = new(StringComparer.OrdinalIgnoreCase) { "public.a" },
+            ["public.c"] = []
+        };
+
+        var result = TopologicalSorter.Sort(tables.ToList(), deps);
+
+        Assert.Equal(3, result.Count);
+        Assert.Contains("public.a", result);
+        Assert.Contains("public.b", result);
+        Assert.Contains("public.c", result);
+        // c has no deps — should be first
+        Assert.Equal("public.c", result[0]);
+    }
+
+    [Fact]
+    public void TopologicalSort_EmptyList_ReturnsEmpty()
+    {
+        var result = TopologicalSorter.Sort(
+            new List<string>(),
+            new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase));
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void TopologicalSort_SingleTable_ReturnsSameTable()
+    {
+        var tables = new[] { "public.users" };
+        var deps = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["public.users"] = []
+        };
+
+        var result = TopologicalSorter.Sort(tables.ToList(), deps);
+
+        Assert.Single(result);
+        Assert.Equal("public.users", result[0]);
+    }
+
+    #endregion
+
+    #region Timeout clamping
+
+    [Theory]
+    [InlineData(null, 600)]    // null → default (600)
+    [InlineData(100, 100)]     // explicit in-range value
+    [InlineData(10, 30)]       // below min → clamped to 30
+    [InlineData(5000, 3600)]   // above max → clamped to 3600
+    [InlineData(30, 30)]       // exact min
+    [InlineData(3600, 3600)]   // exact max
+    public void TimeoutClamping_ViaClampTimeout_ClampsCorrectly(int? value, int expected)
+    {
+        // PostgreSqlBulkCopier uses PgIdentifierHelper.ClampTimeout with DefaultTimeoutSeconds=600
+        Assert.Equal(expected, PgIdentifierHelper.ClampTimeout(value, 600));
+    }
+
+    #endregion
+
+    #region PgIdentifierHelper integration — quoting
+
+    [Theory]
+    [InlineData("public.users", "\"public\".\"users\"")]
+    [InlineData("dbo.Users", "\"public\".\"Users\"")]
+    [InlineData("[dbo].[Users]", "\"public\".\"Users\"")]
+    [InlineData("sales.orders", "\"sales\".\"orders\"")]
+    [InlineData("MyTable", "\"MyTable\"")]
+    public void QuotePgName_VariousInputs_QuotesCorrectly(string input, string expected)
+    {
+        Assert.Equal(expected, PgIdentifierHelper.QuotePgName(input));
+    }
+
+    [Theory]
+    [InlineData("id", "\"id\"")]
+    [InlineData("UserName", "\"UserName\"")]
+    [InlineData("has\"quote", "\"has\"\"quote\"")]
+    [InlineData("has space", "\"has space\"")]
+    [InlineData("123numeric", "\"123numeric\"")]
+    public void QuoteIdentifier_VariousInputs_QuotesCorrectly(string input, string expected)
+    {
+        Assert.Equal(expected, PgIdentifierHelper.QuoteIdentifier(input));
+    }
+
+    #endregion
+
+    #region Progress reporting — SynchronousProgress helper
+
+    [Fact]
+    public async Task CopyDataAsync_EmptyList_ProgressPhaseIsDataMigration()
+    {
+        var copier = new PostgreSqlBulkCopier();
+        var reports = new List<MigrationProgress>();
+        var progress = new SynchronousProgress<MigrationProgress>(reports.Add);
+
+        await copier.CopyDataAsync(
+            "Host=fake;Database=source",
+            "Host=fake;Database=target",
+            Array.Empty<string>(),
+            progress);
+
+        Assert.All(reports, r => Assert.Equal("DataMigration", r.Phase));
+    }
+
+    [Fact]
+    public async Task CopyDataAsync_EmptyList_ProgressRowsProcessedIsZero()
+    {
+        var copier = new PostgreSqlBulkCopier();
+        var reports = new List<MigrationProgress>();
+        var progress = new SynchronousProgress<MigrationProgress>(reports.Add);
+
+        await copier.CopyDataAsync(
+            "Host=fake;Database=source",
+            "Host=fake;Database=target",
+            Array.Empty<string>(),
+            progress);
+
+        Assert.Single(reports);
+        Assert.Equal(0, reports[0].RowsProcessed);
+    }
+
+    #endregion
+
+    #region COPY command structure — text mode
+
+    [Fact]
+    public void BuildCopyExportCommand_UsesTextMode_NoFormatSpecifier()
+    {
+        var result = PostgreSqlBulkCopier.BuildCopyExportCommand(
+            "public.users",
+            new[] { "id" });
+
+        // Text mode COPY does not include FORMAT specification
+        Assert.DoesNotContain("FORMAT", result);
+        Assert.DoesNotContain("BINARY", result);
+        Assert.Contains("TO STDOUT", result);
+    }
+
+    [Fact]
+    public void BuildCopyImportCommand_UsesTextMode_NoFormatSpecifier()
+    {
+        var result = PostgreSqlBulkCopier.BuildCopyImportCommand(
+            "public.users",
+            new[] { "id" });
+
+        Assert.DoesNotContain("FORMAT", result);
+        Assert.DoesNotContain("BINARY", result);
+        Assert.Contains("FROM STDIN", result);
+    }
+
+    [Theory]
+    [InlineData("public.users", new[] { "id", "name" },
+        "COPY \"public\".\"users\" (\"id\", \"name\") TO STDOUT")]
+    [InlineData("dbo.Products", new[] { "ProductId" },
+        "COPY \"public\".\"Products\" (\"ProductId\") TO STDOUT")]
+    [InlineData("custom.items", new[] { "a", "b", "c" },
+        "COPY \"custom\".\"items\" (\"a\", \"b\", \"c\") TO STDOUT")]
+    public void BuildCopyExportCommand_ParameterizedCases_GeneratesCorrectSql(
+        string tableName, string[] columns, string expected)
+    {
+        Assert.Equal(expected, PostgreSqlBulkCopier.BuildCopyExportCommand(tableName, columns));
+    }
+
+    [Theory]
+    [InlineData("public.users", new[] { "id", "name" },
+        "COPY \"public\".\"users\" (\"id\", \"name\") FROM STDIN")]
+    [InlineData("dbo.Products", new[] { "ProductId" },
+        "COPY \"public\".\"Products\" (\"ProductId\") FROM STDIN")]
+    public void BuildCopyImportCommand_ParameterizedCases_GeneratesCorrectSql(
+        string tableName, string[] columns, string expected)
+    {
+        Assert.Equal(expected, PostgreSqlBulkCopier.BuildCopyImportCommand(tableName, columns));
+    }
+
+    #endregion
+
+    /// <summary>
+    /// Synchronous IProgress implementation for unit testing.
+    /// Unlike Progress{T}, this invokes the callback synchronously on the calling thread.
+    /// </summary>
+    private sealed class SynchronousProgress<T> : IProgress<T>
+    {
+        private readonly Action<T> _handler;
+        public SynchronousProgress(Action<T> handler) => _handler = handler;
+        public void Report(T value) => _handler(value);
+    }
+}

--- a/tests/Scaffold.Migration.Tests/PostgreSql/PostgreSqlBulkCopierTests.cs
+++ b/tests/Scaffold.Migration.Tests/PostgreSql/PostgreSqlBulkCopierTests.cs
@@ -211,7 +211,7 @@ public class PostgreSqlBulkCopierTests
             "id");
 
         Assert.Equal(
-            "SELECT setval(\"public\".\"users_id_seq\"::text::regclass, COALESCE((SELECT MAX(\"id\") FROM \"public\".\"users\"), 1), true)",
+            "SELECT setval('public.users_id_seq'::regclass, COALESCE((SELECT MAX(\"id\") FROM \"public\".\"users\"), 1), COALESCE((SELECT MAX(\"id\") FROM \"public\".\"users\") IS NOT NULL, false))",
             result);
     }
 
@@ -224,7 +224,7 @@ public class PostgreSqlBulkCopierTests
             "order_id");
 
         Assert.Equal(
-            "SELECT setval(\"sales\".\"orders_order_id_seq\"::text::regclass, COALESCE((SELECT MAX(\"order_id\") FROM \"sales\".\"orders\"), 1), true)",
+            "SELECT setval('sales.orders_order_id_seq'::regclass, COALESCE((SELECT MAX(\"order_id\") FROM \"sales\".\"orders\"), 1), COALESCE((SELECT MAX(\"order_id\") FROM \"sales\".\"orders\") IS NOT NULL, false))",
             result);
     }
 
@@ -238,7 +238,7 @@ public class PostgreSqlBulkCopierTests
 
         Assert.Contains("\"my\"\"col\"", result);
         Assert.StartsWith("SELECT setval(", result);
-        Assert.EndsWith(", true)", result);
+        Assert.Contains("IS NOT NULL, false)", result);
     }
 
     [Fact]
@@ -262,7 +262,32 @@ public class PostgreSqlBulkCopierTests
             "col1");
 
         // Must cast to regclass for setval
-        Assert.Contains("::text::regclass", result);
+        Assert.Contains("::regclass", result);
+    }
+
+    [Fact]
+    public void BuildResetSequenceSql_EmptyTable_IsCalledFalse()
+    {
+        var result = PostgreSqlBulkCopier.BuildResetSequenceSql(
+            "public.users_id_seq",
+            "public.users",
+            "id");
+
+        // When table is empty, MAX returns NULL, so IS NOT NULL → false, making is_called=false
+        // This ensures next nextval() returns 1, not 2
+        Assert.Contains("COALESCE((SELECT MAX(\"id\") FROM \"public\".\"users\") IS NOT NULL, false)", result);
+    }
+
+    [Fact]
+    public void BuildResetSequenceSql_SeqNameWithSingleQuote_Escaped()
+    {
+        var result = PostgreSqlBulkCopier.BuildResetSequenceSql(
+            "public.it's_seq",
+            "public.tbl1",
+            "col1");
+
+        // Single quotes in sequence name must be escaped
+        Assert.Contains("'public.it''s_seq'::regclass", result);
     }
 
     #endregion

--- a/tests/Scaffold.Migration.Tests/PostgreSql/PostgreSqlDdlGeneratorTests.cs
+++ b/tests/Scaffold.Migration.Tests/PostgreSql/PostgreSqlDdlGeneratorTests.cs
@@ -1,0 +1,867 @@
+using Scaffold.Migration.PostgreSql;
+using Scaffold.Migration.PostgreSql.Models;
+
+namespace Scaffold.Migration.Tests.PostgreSql;
+
+public class PostgreSqlDdlGeneratorTests
+{
+    private readonly PostgreSqlDdlGenerator _generator = new();
+
+    #region Helpers
+
+    private static PgTableDefinition SimpleTable(
+        string name = "users", string schema = "public") => new()
+    {
+        Schema = schema,
+        TableName = name,
+        Columns =
+        [
+            new PgColumnDefinition
+            {
+                Name = "id", DataType = "integer", FullType = "integer",
+                IsNullable = false, IsIdentity = true, IdentityGeneration = "BY DEFAULT",
+                OrdinalPosition = 1
+            },
+            new PgColumnDefinition
+            {
+                Name = "name", DataType = "character varying", FullType = "character varying(100)",
+                IsNullable = false, OrdinalPosition = 2
+            },
+            new PgColumnDefinition
+            {
+                Name = "email", DataType = "character varying", FullType = "character varying(255)",
+                IsNullable = true, OrdinalPosition = 3
+            }
+        ],
+        PrimaryKey = new PgPrimaryKeyDefinition { Name = "users_pkey", Columns = ["id"] }
+    };
+
+    private static PgTableDefinition OrdersTable() => new()
+    {
+        Schema = "public",
+        TableName = "orders",
+        Columns =
+        [
+            new PgColumnDefinition
+            {
+                Name = "id", DataType = "integer", FullType = "integer",
+                IsNullable = false, IsIdentity = true, IdentityGeneration = "ALWAYS",
+                OrdinalPosition = 1
+            },
+            new PgColumnDefinition
+            {
+                Name = "user_id", DataType = "integer", FullType = "integer",
+                IsNullable = false, OrdinalPosition = 2
+            },
+            new PgColumnDefinition
+            {
+                Name = "amount", DataType = "numeric", FullType = "numeric(18,2)",
+                IsNullable = false, OrdinalPosition = 3
+            },
+            new PgColumnDefinition
+            {
+                Name = "created_at", DataType = "timestamp with time zone",
+                FullType = "timestamp with time zone",
+                IsNullable = false, DefaultExpression = "now()", OrdinalPosition = 4
+            }
+        ],
+        PrimaryKey = new PgPrimaryKeyDefinition { Name = "orders_pkey", Columns = ["id"] },
+        ForeignKeys =
+        [
+            new PgForeignKeyDefinition
+            {
+                Name = "fk_orders_users",
+                ReferencedSchema = "public",
+                ReferencedTable = "users",
+                Columns = ["user_id"],
+                ReferencedColumns = ["id"],
+                DeleteAction = "CASCADE",
+                UpdateAction = "NO ACTION"
+            }
+        ]
+    };
+
+    #endregion
+
+    #region GenerateCreateEnum
+
+    [Fact]
+    public void GenerateCreateEnum_SimpleEnum_ProducesValidDdl()
+    {
+        var enumType = new PgEnumTypeDefinition
+        {
+            Schema = "public",
+            Name = "mood",
+            Labels = ["happy", "sad", "neutral"]
+        };
+
+        var ddl = _generator.GenerateCreateEnum(enumType);
+
+        Assert.Contains("CREATE TYPE", ddl);
+        Assert.Contains("\"public\".\"mood\"", ddl);
+        Assert.Contains("AS ENUM", ddl);
+        Assert.Contains("'happy'", ddl);
+        Assert.Contains("'sad'", ddl);
+        Assert.Contains("'neutral'", ddl);
+        Assert.EndsWith(";", ddl);
+    }
+
+    [Fact]
+    public void GenerateCreateEnum_LabelWithQuote_EscapesCorrectly()
+    {
+        var enumType = new PgEnumTypeDefinition
+        {
+            Schema = "public",
+            Name = "status",
+            Labels = ["it's active", "inactive"]
+        };
+
+        var ddl = _generator.GenerateCreateEnum(enumType);
+
+        Assert.Contains("'it''s active'", ddl);
+    }
+
+    [Fact]
+    public void GenerateCreateEnum_CustomSchema_UsesSchemaPrefix()
+    {
+        var enumType = new PgEnumTypeDefinition
+        {
+            Schema = "myschema",
+            Name = "priority",
+            Labels = ["low", "medium", "high"]
+        };
+
+        var ddl = _generator.GenerateCreateEnum(enumType);
+
+        Assert.Contains("\"myschema\".\"priority\"", ddl);
+    }
+
+    #endregion
+
+    #region GenerateCreateSequence
+
+    [Fact]
+    public void GenerateCreateSequence_DefaultOptions_ProducesValidDdl()
+    {
+        var seq = new PgSequenceDefinition
+        {
+            Schema = "public",
+            Name = "users_id_seq",
+            DataType = "bigint",
+            StartValue = 1,
+            IncrementBy = 1
+        };
+
+        var ddl = _generator.GenerateCreateSequence(seq);
+
+        Assert.Contains("CREATE SEQUENCE", ddl);
+        Assert.Contains("\"public\".\"users_id_seq\"", ddl);
+        Assert.Contains("AS bigint", ddl);
+        Assert.Contains("START WITH 1", ddl);
+        Assert.Contains("INCREMENT BY 1", ddl);
+        Assert.Contains("NO MINVALUE", ddl);
+        Assert.Contains("NO MAXVALUE", ddl);
+        Assert.Contains("NO CYCLE", ddl);
+        Assert.EndsWith(";", ddl);
+    }
+
+    [Fact]
+    public void GenerateCreateSequence_WithCycle_IncludesCycle()
+    {
+        var seq = new PgSequenceDefinition
+        {
+            Schema = "public",
+            Name = "cyclic_seq",
+            DataType = "integer",
+            StartValue = 1,
+            IncrementBy = 1,
+            MinValue = 1,
+            MaxValue = 100,
+            IsCyclic = true
+        };
+
+        var ddl = _generator.GenerateCreateSequence(seq);
+
+        Assert.Contains("MINVALUE 1", ddl);
+        Assert.Contains("MAXVALUE 100", ddl);
+        Assert.Contains(" CYCLE", ddl);
+        Assert.DoesNotContain("NO CYCLE", ddl);
+    }
+
+    [Fact]
+    public void GenerateCreateSequence_WithOwnedBy_IncludesOwnedBy()
+    {
+        var seq = new PgSequenceDefinition
+        {
+            Schema = "public",
+            Name = "users_id_seq",
+            DataType = "bigint",
+            StartValue = 1,
+            IncrementBy = 1,
+            OwnedBy = "public.users.id"
+        };
+
+        var ddl = _generator.GenerateCreateSequence(seq);
+
+        Assert.Contains("OWNED BY \"public\".\"users\".\"id\"", ddl);
+    }
+
+    #endregion
+
+    #region GenerateCreateTable
+
+    [Fact]
+    public void GenerateCreateTable_SimpleTable_ContainsColumnsAndPK()
+    {
+        var table = SimpleTable();
+
+        var ddl = _generator.GenerateCreateTable(table);
+
+        Assert.Contains("CREATE TABLE \"public\".\"users\"", ddl);
+        Assert.Contains("\"id\" integer GENERATED BY DEFAULT AS IDENTITY", ddl);
+        Assert.Contains("\"name\" character varying(100)", ddl);
+        Assert.Contains("NOT NULL", ddl);
+        Assert.Contains("CONSTRAINT \"users_pkey\" PRIMARY KEY (\"id\")", ddl);
+        Assert.EndsWith(");", ddl);
+    }
+
+    [Fact]
+    public void GenerateCreateTable_WithDefault_IncludesDefault()
+    {
+        var table = new PgTableDefinition
+        {
+            Schema = "public",
+            TableName = "events",
+            Columns =
+            [
+                new PgColumnDefinition
+                {
+                    Name = "created_at", DataType = "timestamp with time zone",
+                    FullType = "timestamp with time zone",
+                    IsNullable = false, DefaultExpression = "now()", OrdinalPosition = 1
+                }
+            ]
+        };
+
+        var ddl = _generator.GenerateCreateTable(table);
+
+        Assert.Contains("DEFAULT now()", ddl);
+    }
+
+    [Fact]
+    public void GenerateCreateTable_WithGeneratedColumn_IncludesGeneratedClause()
+    {
+        var table = new PgTableDefinition
+        {
+            Schema = "public",
+            TableName = "products",
+            Columns =
+            [
+                new PgColumnDefinition
+                {
+                    Name = "price", DataType = "numeric", FullType = "numeric(10,2)",
+                    IsNullable = false, OrdinalPosition = 1
+                },
+                new PgColumnDefinition
+                {
+                    Name = "tax", DataType = "numeric", FullType = "numeric(10,2)",
+                    IsNullable = false, OrdinalPosition = 2
+                },
+                new PgColumnDefinition
+                {
+                    Name = "total", DataType = "numeric", FullType = "numeric(10,2)",
+                    IsNullable = false, IsGenerated = true,
+                    GenerationExpression = "price + tax", OrdinalPosition = 3
+                }
+            ]
+        };
+
+        var ddl = _generator.GenerateCreateTable(table);
+
+        Assert.Contains("GENERATED ALWAYS AS (price + tax) STORED", ddl);
+    }
+
+    [Fact]
+    public void GenerateCreateTable_WithIdentityAlways_IncludesAlways()
+    {
+        var table = new PgTableDefinition
+        {
+            Schema = "public",
+            TableName = "audit_log",
+            Columns =
+            [
+                new PgColumnDefinition
+                {
+                    Name = "id", DataType = "bigint", FullType = "bigint",
+                    IsNullable = false, IsIdentity = true, IdentityGeneration = "ALWAYS",
+                    OrdinalPosition = 1
+                }
+            ]
+        };
+
+        var ddl = _generator.GenerateCreateTable(table);
+
+        Assert.Contains("GENERATED ALWAYS AS IDENTITY", ddl);
+    }
+
+    [Fact]
+    public void GenerateCreateTable_WithUniqueConstraint_IncludesUnique()
+    {
+        var table = SimpleTable();
+        table.UniqueConstraints.Add(new PgUniqueConstraintDefinition
+        {
+            Name = "uq_users_email",
+            Columns = ["email"]
+        });
+
+        var ddl = _generator.GenerateCreateTable(table);
+
+        Assert.Contains("CONSTRAINT \"uq_users_email\" UNIQUE (\"email\")", ddl);
+    }
+
+    [Fact]
+    public void GenerateCreateTable_WithCheckConstraint_IncludesCheck()
+    {
+        var table = SimpleTable();
+        table.CheckConstraints.Add(new PgCheckConstraintDefinition
+        {
+            Name = "chk_name_length",
+            Expression = "length(name) > 0"
+        });
+
+        var ddl = _generator.GenerateCreateTable(table);
+
+        Assert.Contains("CONSTRAINT \"chk_name_length\" CHECK (length(name) > 0)", ddl);
+    }
+
+    [Fact]
+    public void GenerateCreateTable_WithCollation_IncludesCollate()
+    {
+        var table = new PgTableDefinition
+        {
+            Schema = "public",
+            TableName = "localized",
+            Columns =
+            [
+                new PgColumnDefinition
+                {
+                    Name = "name", DataType = "text", FullType = "text",
+                    IsNullable = true, OrdinalPosition = 1,
+                    Collation = "en_US.utf8"
+                }
+            ]
+        };
+
+        var ddl = _generator.GenerateCreateTable(table);
+
+        Assert.Contains("COLLATE \"en_US.utf8\"", ddl);
+    }
+
+    [Fact]
+    public void GenerateCreateTable_NullableColumn_OmitsNotNull()
+    {
+        var table = new PgTableDefinition
+        {
+            Schema = "public",
+            TableName = "test",
+            Columns =
+            [
+                new PgColumnDefinition
+                {
+                    Name = "notes", DataType = "text", FullType = "text",
+                    IsNullable = true, OrdinalPosition = 1
+                }
+            ]
+        };
+
+        var ddl = _generator.GenerateCreateTable(table);
+
+        Assert.DoesNotContain("NOT NULL", ddl);
+    }
+
+    #endregion
+
+    #region GenerateAddForeignKey
+
+    [Fact]
+    public void GenerateAddForeignKey_Cascade_ProducesValidDdl()
+    {
+        var table = OrdersTable();
+        var fk = table.ForeignKeys[0];
+
+        var ddl = _generator.GenerateAddForeignKey(table, fk);
+
+        Assert.Contains("ALTER TABLE \"public\".\"orders\"", ddl);
+        Assert.Contains("ADD CONSTRAINT \"fk_orders_users\"", ddl);
+        Assert.Contains("FOREIGN KEY (\"user_id\")", ddl);
+        Assert.Contains("REFERENCES \"public\".\"users\" (\"id\")", ddl);
+        Assert.Contains("ON DELETE CASCADE", ddl);
+        Assert.Contains("ON UPDATE NO ACTION", ddl);
+        Assert.EndsWith(";", ddl);
+    }
+
+    [Theory]
+    [InlineData("CASCADE", "CASCADE")]
+    [InlineData("SET NULL", "SET NULL")]
+    [InlineData("SET DEFAULT", "SET DEFAULT")]
+    [InlineData("RESTRICT", "RESTRICT")]
+    [InlineData("NO ACTION", "NO ACTION")]
+    public void GenerateAddForeignKey_ReferentialActions_ProducesCorrectAction(
+        string action, string expected)
+    {
+        var table = new PgTableDefinition { Schema = "public", TableName = "child" };
+        var fk = new PgForeignKeyDefinition
+        {
+            Name = "fk_test",
+            ReferencedSchema = "public",
+            ReferencedTable = "parent",
+            Columns = ["parent_id"],
+            ReferencedColumns = ["id"],
+            DeleteAction = action,
+            UpdateAction = action
+        };
+
+        var ddl = _generator.GenerateAddForeignKey(table, fk);
+
+        Assert.Contains($"ON DELETE {expected}", ddl);
+        Assert.Contains($"ON UPDATE {expected}", ddl);
+    }
+
+    [Fact]
+    public void GenerateAddForeignKey_InvalidAction_DefaultsToNoAction()
+    {
+        var table = new PgTableDefinition { Schema = "public", TableName = "child" };
+        var fk = new PgForeignKeyDefinition
+        {
+            Name = "fk_test",
+            ReferencedSchema = "public",
+            ReferencedTable = "parent",
+            Columns = ["parent_id"],
+            ReferencedColumns = ["id"],
+            DeleteAction = "INVALID",
+            UpdateAction = "INVALID"
+        };
+
+        var ddl = _generator.GenerateAddForeignKey(table, fk);
+
+        Assert.Contains("ON DELETE NO ACTION", ddl);
+        Assert.Contains("ON UPDATE NO ACTION", ddl);
+    }
+
+    [Fact]
+    public void GenerateAddForeignKey_MultiColumn_ListsAllColumns()
+    {
+        var table = new PgTableDefinition { Schema = "public", TableName = "child" };
+        var fk = new PgForeignKeyDefinition
+        {
+            Name = "fk_composite",
+            ReferencedSchema = "public",
+            ReferencedTable = "parent",
+            Columns = ["col_a", "col_b"],
+            ReferencedColumns = ["ref_a", "ref_b"],
+            DeleteAction = "NO ACTION",
+            UpdateAction = "NO ACTION"
+        };
+
+        var ddl = _generator.GenerateAddForeignKey(table, fk);
+
+        Assert.Contains("FOREIGN KEY (\"col_a\", \"col_b\")", ddl);
+        Assert.Contains("(\"ref_a\", \"ref_b\")", ddl);
+    }
+
+    #endregion
+
+    #region GenerateCreateIndex
+
+    [Fact]
+    public void GenerateCreateIndex_WithRawDdl_UsesRawDdlDirectly()
+    {
+        var table = SimpleTable();
+        var index = new PgIndexDefinition
+        {
+            Name = "idx_users_email",
+            Columns = ["email"],
+            RawDdl = "CREATE INDEX idx_users_email ON public.users USING btree (email)"
+        };
+
+        var ddl = _generator.GenerateCreateIndex(table, index);
+
+        Assert.Equal("CREATE INDEX idx_users_email ON public.users USING btree (email);", ddl);
+    }
+
+    [Fact]
+    public void GenerateCreateIndex_WithRawDdlSemicolon_DoesNotDoubleSemicolon()
+    {
+        var table = SimpleTable();
+        var index = new PgIndexDefinition
+        {
+            Name = "idx_test",
+            RawDdl = "CREATE INDEX idx_test ON public.users (email);"
+        };
+
+        var ddl = _generator.GenerateCreateIndex(table, index);
+
+        Assert.Equal("CREATE INDEX idx_test ON public.users (email);", ddl);
+        Assert.DoesNotContain(";;", ddl);
+    }
+
+    [Fact]
+    public void GenerateCreateIndex_NoRawDdl_ConstructsFromParts()
+    {
+        var table = SimpleTable();
+        var index = new PgIndexDefinition
+        {
+            Name = "idx_users_email",
+            Columns = ["email"],
+            IsUnique = false,
+            AccessMethod = "btree"
+        };
+
+        var ddl = _generator.GenerateCreateIndex(table, index);
+
+        Assert.Contains("CREATE INDEX \"idx_users_email\"", ddl);
+        Assert.Contains("ON \"public\".\"users\"", ddl);
+        Assert.Contains("(\"email\")", ddl);
+        Assert.DoesNotContain("USING", ddl); // btree is default, should be omitted
+        Assert.EndsWith(";", ddl);
+    }
+
+    [Fact]
+    public void GenerateCreateIndex_UniqueNoRawDdl_IncludesUnique()
+    {
+        var table = SimpleTable();
+        var index = new PgIndexDefinition
+        {
+            Name = "idx_unique_email",
+            Columns = ["email"],
+            IsUnique = true,
+            AccessMethod = "btree"
+        };
+
+        var ddl = _generator.GenerateCreateIndex(table, index);
+
+        Assert.Contains("CREATE UNIQUE INDEX", ddl);
+    }
+
+    [Fact]
+    public void GenerateCreateIndex_NonBtreeMethod_IncludesUsing()
+    {
+        var table = SimpleTable();
+        var index = new PgIndexDefinition
+        {
+            Name = "idx_gin",
+            Columns = ["tags"],
+            AccessMethod = "gin"
+        };
+
+        var ddl = _generator.GenerateCreateIndex(table, index);
+
+        Assert.Contains("USING gin", ddl);
+    }
+
+    [Fact]
+    public void GenerateCreateIndex_WithIncludedColumns_IncludesInclude()
+    {
+        var table = SimpleTable();
+        var index = new PgIndexDefinition
+        {
+            Name = "idx_covering",
+            Columns = ["name"],
+            IncludedColumns = ["email"],
+            AccessMethod = "btree"
+        };
+
+        var ddl = _generator.GenerateCreateIndex(table, index);
+
+        Assert.Contains("INCLUDE (\"email\")", ddl);
+    }
+
+    [Fact]
+    public void GenerateCreateIndex_WithFilter_IncludesWhere()
+    {
+        var table = SimpleTable();
+        var index = new PgIndexDefinition
+        {
+            Name = "idx_active",
+            Columns = ["email"],
+            AccessMethod = "btree",
+            FilterExpression = "is_active = true"
+        };
+
+        var ddl = _generator.GenerateCreateIndex(table, index);
+
+        Assert.Contains("WHERE is_active = true", ddl);
+    }
+
+    #endregion
+
+    #region GenerateCreateView
+
+    [Fact]
+    public void GenerateCreateView_RegularView_ProducesCreateOrReplace()
+    {
+        var view = new PgViewDefinition
+        {
+            Schema = "public",
+            Name = "active_users",
+            Definition = " SELECT id, name FROM users WHERE is_active = true",
+            IsMaterialized = false
+        };
+
+        var ddl = _generator.GenerateCreateView(view);
+
+        Assert.Contains("CREATE OR REPLACE VIEW", ddl);
+        Assert.Contains("\"public\".\"active_users\"", ddl);
+        Assert.Contains("SELECT id, name FROM users WHERE is_active = true", ddl);
+        Assert.EndsWith(";", ddl);
+    }
+
+    [Fact]
+    public void GenerateCreateView_MaterializedView_ProducesCreateMaterialized()
+    {
+        var view = new PgViewDefinition
+        {
+            Schema = "public",
+            Name = "summary_stats",
+            Definition = " SELECT count(*) FROM users",
+            IsMaterialized = true
+        };
+
+        var ddl = _generator.GenerateCreateView(view);
+
+        Assert.Contains("CREATE MATERIALIZED VIEW", ddl);
+        Assert.DoesNotContain("OR REPLACE", ddl);
+        Assert.Contains("\"public\".\"summary_stats\"", ddl);
+        Assert.EndsWith(";", ddl);
+    }
+
+    [Fact]
+    public void GenerateCreateView_DefinitionWithSemicolon_DoesNotDoubleSemicolon()
+    {
+        var view = new PgViewDefinition
+        {
+            Schema = "public",
+            Name = "test_view",
+            Definition = " SELECT 1;",
+            IsMaterialized = false
+        };
+
+        var ddl = _generator.GenerateCreateView(view);
+
+        Assert.DoesNotContain(";;", ddl);
+        Assert.EndsWith(";", ddl);
+    }
+
+    #endregion
+
+    #region GenerateCreateFunction
+
+    [Fact]
+    public void GenerateCreateFunction_PassesThroughDefinition()
+    {
+        var function = new PgFunctionDefinition
+        {
+            Schema = "public",
+            Name = "add_numbers",
+            Definition = "CREATE OR REPLACE FUNCTION public.add_numbers(a integer, b integer)\nRETURNS integer\nLANGUAGE plpgsql\nAS $function$\nBEGIN\n  RETURN a + b;\nEND;\n$function$",
+            Language = "plpgsql",
+            Kind = "f"
+        };
+
+        var ddl = _generator.GenerateCreateFunction(function);
+
+        Assert.StartsWith("CREATE OR REPLACE FUNCTION", ddl);
+        Assert.Contains("add_numbers", ddl);
+        Assert.Contains("RETURN a + b;", ddl);
+    }
+
+    [Fact]
+    public void GenerateCreateFunction_NoTrailingSemicolon_AddsSemicolon()
+    {
+        var function = new PgFunctionDefinition
+        {
+            Schema = "public",
+            Name = "get_one",
+            Definition = "CREATE OR REPLACE FUNCTION public.get_one()\nRETURNS integer\nLANGUAGE sql\nAS $function$ SELECT 1 $function$",
+            Language = "sql",
+            Kind = "f"
+        };
+
+        var ddl = _generator.GenerateCreateFunction(function);
+
+        Assert.EndsWith(";", ddl);
+    }
+
+    #endregion
+
+    #region GenerateDdl — Ordering
+
+    [Fact]
+    public void GenerateDdl_ProducesCorrectOrdering()
+    {
+        var snapshot = new PgSchemaSnapshot
+        {
+            EnumTypes =
+            [
+                new PgEnumTypeDefinition
+                {
+                    Schema = "public", Name = "status",
+                    Labels = ["active", "inactive"]
+                }
+            ],
+            Sequences =
+            [
+                new PgSequenceDefinition
+                {
+                    Schema = "public", Name = "users_id_seq",
+                    DataType = "bigint", StartValue = 1, IncrementBy = 1
+                }
+            ],
+            Tables = [SimpleTable(), OrdersTable()],
+            Views =
+            [
+                new PgViewDefinition
+                {
+                    Schema = "public", Name = "active_users",
+                    Definition = " SELECT * FROM users"
+                }
+            ],
+            Functions =
+            [
+                new PgFunctionDefinition
+                {
+                    Schema = "public", Name = "get_user",
+                    Definition = "CREATE OR REPLACE FUNCTION public.get_user() RETURNS void LANGUAGE sql AS $$ SELECT 1 $$"
+                }
+            ]
+        };
+
+        var ddl = _generator.GenerateDdl(snapshot);
+
+        // Find positions of each category
+        var enumIdx = ddl.FindIndex(s => s.Contains("CREATE TYPE"));
+        var seqIdx = ddl.FindIndex(s => s.Contains("CREATE SEQUENCE"));
+        var tableIdx = ddl.FindIndex(s => s.Contains("CREATE TABLE"));
+        var fkIdx = ddl.FindIndex(s => s.Contains("ALTER TABLE"));
+        var viewIdx = ddl.FindIndex(s => s.Contains("CREATE OR REPLACE VIEW"));
+        var funcIdx = ddl.FindIndex(s => s.Contains("CREATE OR REPLACE FUNCTION"));
+
+        Assert.True(enumIdx >= 0, "Should contain enum DDL");
+        Assert.True(seqIdx >= 0, "Should contain sequence DDL");
+        Assert.True(tableIdx >= 0, "Should contain table DDL");
+        Assert.True(fkIdx >= 0, "Should contain FK DDL");
+        Assert.True(viewIdx >= 0, "Should contain view DDL");
+        Assert.True(funcIdx >= 0, "Should contain function DDL");
+
+        // Order: enum < sequence < table < FK < view < function
+        Assert.True(enumIdx < seqIdx, "Enums should come before sequences");
+        Assert.True(seqIdx < tableIdx, "Sequences should come before tables");
+        Assert.True(tableIdx < fkIdx, "Tables should come before FKs");
+        Assert.True(fkIdx < viewIdx, "FKs should come before views");
+        Assert.True(viewIdx < funcIdx, "Views should come before functions");
+    }
+
+    [Fact]
+    public void GenerateDdl_TablesInDependencyOrder_ParentsBeforeChildren()
+    {
+        var snapshot = new PgSchemaSnapshot
+        {
+            Tables = [OrdersTable(), SimpleTable()], // Orders first, but depends on Users
+        };
+
+        var ddl = _generator.GenerateDdl(snapshot);
+
+        var userTableIdx = ddl.FindIndex(s => s.Contains("\"users\"") && s.Contains("CREATE TABLE"));
+        var orderTableIdx = ddl.FindIndex(s => s.Contains("\"orders\"") && s.Contains("CREATE TABLE"));
+
+        Assert.True(userTableIdx >= 0, "Should contain users table");
+        Assert.True(orderTableIdx >= 0, "Should contain orders table");
+        Assert.True(userTableIdx < orderTableIdx, "Users (parent) should come before orders (child)");
+    }
+
+    [Fact]
+    public void GenerateDdl_EmptySnapshot_ReturnsEmptyList()
+    {
+        var snapshot = new PgSchemaSnapshot();
+
+        var ddl = _generator.GenerateDdl(snapshot);
+
+        Assert.Empty(ddl);
+    }
+
+    #endregion
+
+    #region Identifier Quoting
+
+    [Fact]
+    public void GenerateCreateTable_SpecialCharacterNames_QuotesCorrectly()
+    {
+        var table = new PgTableDefinition
+        {
+            Schema = "my schema",
+            TableName = "my-table",
+            Columns =
+            [
+                new PgColumnDefinition
+                {
+                    Name = "my column", DataType = "text", FullType = "text",
+                    IsNullable = true, OrdinalPosition = 1
+                }
+            ]
+        };
+
+        var ddl = _generator.GenerateCreateTable(table);
+
+        Assert.Contains("\"my schema\".\"my-table\"", ddl);
+        Assert.Contains("\"my column\"", ddl);
+    }
+
+    [Fact]
+    public void GenerateCreateTable_NameWithDoubleQuote_EscapesCorrectly()
+    {
+        var table = new PgTableDefinition
+        {
+            Schema = "public",
+            TableName = "table\"name",
+            Columns =
+            [
+                new PgColumnDefinition
+                {
+                    Name = "col\"name", DataType = "text", FullType = "text",
+                    IsNullable = true, OrdinalPosition = 1
+                }
+            ]
+        };
+
+        var ddl = _generator.GenerateCreateTable(table);
+
+        Assert.Contains("\"table\"\"name\"", ddl);
+        Assert.Contains("\"col\"\"name\"", ddl);
+    }
+
+    #endregion
+
+    #region GenerateCreateIndex — Access Methods
+
+    [Theory]
+    [InlineData("hash")]
+    [InlineData("gist")]
+    [InlineData("gin")]
+    [InlineData("brin")]
+    public void GenerateCreateIndex_NonBtreeAccessMethods_IncludesUsing(string method)
+    {
+        var table = SimpleTable();
+        var index = new PgIndexDefinition
+        {
+            Name = "idx_test",
+            Columns = ["name"],
+            AccessMethod = method
+        };
+
+        var ddl = _generator.GenerateCreateIndex(table, index);
+
+        Assert.Contains($"USING {method}", ddl);
+    }
+
+    #endregion
+}

--- a/tests/Scaffold.Migration.Tests/PostgreSql/PostgreSqlMigratorTests.cs
+++ b/tests/Scaffold.Migration.Tests/PostgreSql/PostgreSqlMigratorTests.cs
@@ -1,0 +1,562 @@
+using Moq;
+using Scaffold.Core.Enums;
+using Scaffold.Core.Interfaces;
+using Scaffold.Core.Models;
+using Scaffold.Migration.PostgreSql;
+using Scaffold.Migration.PostgreSql.Models;
+using Scaffold.Migration.SqlServer;
+
+namespace Scaffold.Migration.Tests.PostgreSql;
+
+public class PostgreSqlMigratorTests
+{
+    private static MigrationPlan CreateValidPlan(params string[] tables) => new()
+    {
+        Id = Guid.NewGuid(),
+        ProjectId = Guid.NewGuid(),
+        SourceConnectionString = "Host=source;Database=testdb;Username=postgres;",
+        ExistingTargetConnectionString = "Host=target;Database=testdb;Username=postgres;",
+        SourcePlatform = DatabasePlatform.PostgreSql,
+        TargetPlatform = DatabasePlatform.PostgreSql,
+        IncludedObjects = tables.ToList()
+    };
+
+    private static PostgreSqlMigrator CreateMigrator(
+        Mock<PostgreSqlSchemaExtractor>? schemaExtractor = null,
+        Mock<PostgreSqlDdlGenerator>? ddlGenerator = null,
+        Mock<PostgreSqlBulkCopier>? bulkCopier = null,
+        Mock<PostgreSqlScriptExecutor>? scriptExecutor = null,
+        Mock<PostgreSqlToPostgreSqlValidationEngine>? validationEngine = null,
+        Mock<AzureExtensionHandler>? extensionHandler = null)
+    {
+        return new PostgreSqlMigrator(
+            (schemaExtractor ?? new Mock<PostgreSqlSchemaExtractor>()).Object,
+            (ddlGenerator ?? new Mock<PostgreSqlDdlGenerator>()).Object,
+            (bulkCopier ?? new Mock<PostgreSqlBulkCopier>()).Object,
+            (scriptExecutor ?? new Mock<PostgreSqlScriptExecutor>()).Object,
+            (validationEngine ?? new Mock<PostgreSqlToPostgreSqlValidationEngine>()).Object,
+            (extensionHandler ?? new Mock<AzureExtensionHandler>()).Object);
+    }
+
+    #region Constructor null guards
+
+    [Fact]
+    public void Constructor_NullSchemaExtractor_ThrowsArgumentNullException()
+    {
+        var ex = Assert.Throws<ArgumentNullException>(() => new PostgreSqlMigrator(
+            null!,
+            new PostgreSqlDdlGenerator(),
+            new PostgreSqlBulkCopier(),
+            new PostgreSqlScriptExecutor(),
+            new PostgreSqlToPostgreSqlValidationEngine(),
+            new AzureExtensionHandler()));
+        Assert.Equal("schemaExtractor", ex.ParamName);
+    }
+
+    [Fact]
+    public void Constructor_NullDdlGenerator_ThrowsArgumentNullException()
+    {
+        var ex = Assert.Throws<ArgumentNullException>(() => new PostgreSqlMigrator(
+            new PostgreSqlSchemaExtractor(),
+            null!,
+            new PostgreSqlBulkCopier(),
+            new PostgreSqlScriptExecutor(),
+            new PostgreSqlToPostgreSqlValidationEngine(),
+            new AzureExtensionHandler()));
+        Assert.Equal("ddlGenerator", ex.ParamName);
+    }
+
+    [Fact]
+    public void Constructor_NullBulkCopier_ThrowsArgumentNullException()
+    {
+        var ex = Assert.Throws<ArgumentNullException>(() => new PostgreSqlMigrator(
+            new PostgreSqlSchemaExtractor(),
+            new PostgreSqlDdlGenerator(),
+            null!,
+            new PostgreSqlScriptExecutor(),
+            new PostgreSqlToPostgreSqlValidationEngine(),
+            new AzureExtensionHandler()));
+        Assert.Equal("bulkCopier", ex.ParamName);
+    }
+
+    [Fact]
+    public void Constructor_NullScriptExecutor_ThrowsArgumentNullException()
+    {
+        var ex = Assert.Throws<ArgumentNullException>(() => new PostgreSqlMigrator(
+            new PostgreSqlSchemaExtractor(),
+            new PostgreSqlDdlGenerator(),
+            new PostgreSqlBulkCopier(),
+            null!,
+            new PostgreSqlToPostgreSqlValidationEngine(),
+            new AzureExtensionHandler()));
+        Assert.Equal("scriptExecutor", ex.ParamName);
+    }
+
+    [Fact]
+    public void Constructor_NullValidationEngine_ThrowsArgumentNullException()
+    {
+        var ex = Assert.Throws<ArgumentNullException>(() => new PostgreSqlMigrator(
+            new PostgreSqlSchemaExtractor(),
+            new PostgreSqlDdlGenerator(),
+            new PostgreSqlBulkCopier(),
+            new PostgreSqlScriptExecutor(),
+            null!,
+            new AzureExtensionHandler()));
+        Assert.Equal("validationEngine", ex.ParamName);
+    }
+
+    [Fact]
+    public void Constructor_NullExtensionHandler_ThrowsArgumentNullException()
+    {
+        var ex = Assert.Throws<ArgumentNullException>(() => new PostgreSqlMigrator(
+            new PostgreSqlSchemaExtractor(),
+            new PostgreSqlDdlGenerator(),
+            new PostgreSqlBulkCopier(),
+            new PostgreSqlScriptExecutor(),
+            new PostgreSqlToPostgreSqlValidationEngine(),
+            null!));
+        Assert.Equal("extensionHandler", ex.ParamName);
+    }
+
+    #endregion
+
+    #region SourcePlatform
+
+    [Fact]
+    public void SourcePlatform_ReturnsPostgreSql()
+    {
+        var migrator = CreateMigrator();
+        Assert.Equal("PostgreSql", migrator.SourcePlatform);
+    }
+
+    #endregion
+
+    #region ExecuteCutoverAsync — connection string validation
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task ExecuteCutoverAsync_NullOrEmptySourceConnectionString_ReturnsFailure(string? source)
+    {
+        var migrator = CreateMigrator();
+        var plan = CreateValidPlan();
+        plan.SourceConnectionString = source;
+
+        var result = await migrator.ExecuteCutoverAsync(plan);
+
+        Assert.False(result.Success);
+        Assert.Contains(result.Errors, e => e.Contains("SourceConnectionString"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task ExecuteCutoverAsync_NullOrEmptyTargetConnectionString_ReturnsFailure(string? target)
+    {
+        var migrator = CreateMigrator();
+        var plan = CreateValidPlan();
+        plan.ExistingTargetConnectionString = target;
+
+        var result = await migrator.ExecuteCutoverAsync(plan);
+
+        Assert.False(result.Success);
+        Assert.Contains(result.Errors, e => e.Contains("ExistingTargetConnectionString"));
+    }
+
+    #endregion
+
+    #region StartContinuousSyncAsync — not supported
+
+    [Fact]
+    public async Task StartContinuousSyncAsync_ThrowsNotSupportedException()
+    {
+        var migrator = CreateMigrator();
+        var plan = CreateValidPlan();
+
+        var ex = await Assert.ThrowsAsync<NotSupportedException>(
+            () => migrator.StartContinuousSyncAsync(plan));
+        Assert.Contains("logical replication", ex.Message);
+    }
+
+    #endregion
+
+    #region CompleteCutoverAsync — not supported
+
+    [Fact]
+    public async Task CompleteCutoverAsync_ThrowsNotSupportedException()
+    {
+        var migrator = CreateMigrator();
+
+        var ex = await Assert.ThrowsAsync<NotSupportedException>(
+            () => migrator.CompleteCutoverAsync(Guid.NewGuid()));
+        Assert.Contains("StartContinuousSyncAsync", ex.Message);
+    }
+
+    #endregion
+
+    #region ExecuteCutoverAsync — extension failure causes early return
+
+    [Fact]
+    public async Task ExecuteCutoverAsync_ExtensionFailure_ReturnsFailedResult()
+    {
+        // Arrange
+        var schemaExtractor = new Mock<PostgreSqlSchemaExtractor>();
+        var extensionHandler = new Mock<AzureExtensionHandler>();
+
+        schemaExtractor
+            .Setup(s => s.ExtractSchemaAsync(
+                It.IsAny<string>(), It.IsAny<IReadOnlyList<string>?>(),
+                It.IsAny<IProgress<MigrationProgress>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PgSchemaSnapshot
+            {
+                Extensions = ["pg_trgm", "unsupported_ext"],
+                Tables = []
+            });
+
+        extensionHandler
+            .Setup(e => e.InstallExtensionsAsync(
+                It.IsAny<string>(), It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<IProgress<MigrationProgress>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ExtensionMigrationResult
+            {
+                Installed = [],
+                Failed = ["unsupported_ext"],
+                Warnings =
+                [
+                    new ExtensionWarning
+                    {
+                        ExtensionName = "unsupported_ext",
+                        Message = "Failed to install extension 'unsupported_ext'",
+                        Severity = ExtensionWarningSeverity.Error
+                    }
+                ]
+            });
+
+        var migrator = CreateMigrator(
+            schemaExtractor: schemaExtractor,
+            extensionHandler: extensionHandler);
+
+        var plan = CreateValidPlan();
+
+        // Act
+        var result = await migrator.ExecuteCutoverAsync(plan);
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.Single(result.Errors);
+        Assert.Contains("unsupported_ext", result.Errors[0]);
+    }
+
+    #endregion
+
+    #region ExecuteCutoverAsync — progress reporting
+
+    [Fact]
+    public async Task ExecuteCutoverAsync_ReportsProgressForEachPhase()
+    {
+        // Arrange
+        var schemaExtractor = new Mock<PostgreSqlSchemaExtractor>();
+        var ddlGenerator = new Mock<PostgreSqlDdlGenerator>();
+        var bulkCopier = new Mock<PostgreSqlBulkCopier>();
+        var scriptExecutor = new Mock<PostgreSqlScriptExecutor>();
+        var validationEngine = new Mock<PostgreSqlToPostgreSqlValidationEngine>();
+        var extensionHandler = new Mock<AzureExtensionHandler>();
+
+        var snapshot = new PgSchemaSnapshot
+        {
+            Extensions = [],
+            Tables =
+            [
+                new PgTableDefinition { Schema = "public", TableName = "users" }
+            ]
+        };
+
+        schemaExtractor
+            .Setup(s => s.ExtractSchemaAsync(
+                It.IsAny<string>(), It.IsAny<IReadOnlyList<string>?>(),
+                It.IsAny<IProgress<MigrationProgress>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(snapshot);
+
+        extensionHandler
+            .Setup(e => e.InstallExtensionsAsync(
+                It.IsAny<string>(), It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<IProgress<MigrationProgress>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ExtensionMigrationResult());
+
+        ddlGenerator
+            .Setup(d => d.GenerateDdl(It.IsAny<PgSchemaSnapshot>()))
+            .Returns([]);
+
+        bulkCopier
+            .Setup(b => b.CopyDataAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<IProgress<MigrationProgress>?>(), It.IsAny<int?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(100L);
+
+        bulkCopier
+            .Setup(b => b.ResetSequencesAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        validationEngine
+            .Setup(v => v.ValidateAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationSummary { AllPassed = true, Results = [] });
+
+        var reportedPhases = new List<string>();
+        var progress = new Mock<IProgress<MigrationProgress>>();
+        progress.Setup(p => p.Report(It.IsAny<MigrationProgress>()))
+            .Callback<MigrationProgress>(mp => reportedPhases.Add(mp.Phase));
+
+        var migrator = CreateMigrator(
+            schemaExtractor: schemaExtractor,
+            ddlGenerator: ddlGenerator,
+            bulkCopier: bulkCopier,
+            scriptExecutor: scriptExecutor,
+            validationEngine: validationEngine,
+            extensionHandler: extensionHandler);
+
+        var plan = CreateValidPlan();
+
+        // Act
+        var result = await migrator.ExecuteCutoverAsync(plan, progress.Object);
+
+        // Assert
+        Assert.True(result.Success);
+        Assert.Contains("SchemaExtraction", reportedPhases);
+        Assert.Contains("Extensions", reportedPhases);
+        Assert.Contains("SchemaDeployment", reportedPhases);
+        Assert.Contains("DataMigration", reportedPhases);
+        Assert.Contains("SequenceReset", reportedPhases);
+        Assert.Contains("Validation", reportedPhases);
+    }
+
+    #endregion
+
+    #region ExecuteCutoverAsync — validation results propagated
+
+    [Fact]
+    public async Task ExecuteCutoverAsync_PropagatesValidationResults()
+    {
+        // Arrange
+        var schemaExtractor = new Mock<PostgreSqlSchemaExtractor>();
+        var ddlGenerator = new Mock<PostgreSqlDdlGenerator>();
+        var bulkCopier = new Mock<PostgreSqlBulkCopier>();
+        var validationEngine = new Mock<PostgreSqlToPostgreSqlValidationEngine>();
+        var extensionHandler = new Mock<AzureExtensionHandler>();
+
+        var snapshot = new PgSchemaSnapshot
+        {
+            Extensions = [],
+            Tables =
+            [
+                new PgTableDefinition { Schema = "public", TableName = "orders" }
+            ]
+        };
+
+        schemaExtractor
+            .Setup(s => s.ExtractSchemaAsync(
+                It.IsAny<string>(), It.IsAny<IReadOnlyList<string>?>(),
+                It.IsAny<IProgress<MigrationProgress>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(snapshot);
+
+        extensionHandler
+            .Setup(e => e.InstallExtensionsAsync(
+                It.IsAny<string>(), It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<IProgress<MigrationProgress>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ExtensionMigrationResult());
+
+        ddlGenerator
+            .Setup(d => d.GenerateDdl(It.IsAny<PgSchemaSnapshot>()))
+            .Returns([]);
+
+        bulkCopier
+            .Setup(b => b.CopyDataAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<IProgress<MigrationProgress>?>(), It.IsAny<int?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(500L);
+
+        bulkCopier
+            .Setup(b => b.ResetSequencesAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var validationResults = new List<ValidationResult>
+        {
+            new() { TableName = "public.orders", SourceRowCount = 500, TargetRowCount = 500, ChecksumMatch = true }
+        };
+
+        validationEngine
+            .Setup(v => v.ValidateAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationSummary
+            {
+                AllPassed = true,
+                Results = validationResults,
+                TablesValidated = 1,
+                TablesPassed = 1,
+                TablesFailed = 0
+            });
+
+        var migrator = CreateMigrator(
+            schemaExtractor: schemaExtractor,
+            ddlGenerator: ddlGenerator,
+            bulkCopier: bulkCopier,
+            validationEngine: validationEngine,
+            extensionHandler: extensionHandler);
+
+        var plan = CreateValidPlan();
+
+        // Act
+        var result = await migrator.ExecuteCutoverAsync(plan);
+
+        // Assert
+        Assert.True(result.Success);
+        Assert.Equal(500L, result.RowsMigrated);
+        Assert.Single(result.Validations);
+        Assert.Equal("public.orders", result.Validations[0].TableName);
+        Assert.True(result.Validations[0].Passed);
+    }
+
+    #endregion
+
+    #region ExecuteCutoverAsync — validation failure → result not successful
+
+    [Fact]
+    public async Task ExecuteCutoverAsync_ValidationFailure_ReturnsFailedResult()
+    {
+        // Arrange
+        var schemaExtractor = new Mock<PostgreSqlSchemaExtractor>();
+        var ddlGenerator = new Mock<PostgreSqlDdlGenerator>();
+        var bulkCopier = new Mock<PostgreSqlBulkCopier>();
+        var validationEngine = new Mock<PostgreSqlToPostgreSqlValidationEngine>();
+        var extensionHandler = new Mock<AzureExtensionHandler>();
+
+        var snapshot = new PgSchemaSnapshot
+        {
+            Extensions = [],
+            Tables = [new PgTableDefinition { Schema = "public", TableName = "orders" }]
+        };
+
+        schemaExtractor
+            .Setup(s => s.ExtractSchemaAsync(
+                It.IsAny<string>(), It.IsAny<IReadOnlyList<string>?>(),
+                It.IsAny<IProgress<MigrationProgress>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(snapshot);
+
+        extensionHandler
+            .Setup(e => e.InstallExtensionsAsync(
+                It.IsAny<string>(), It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<IProgress<MigrationProgress>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ExtensionMigrationResult());
+
+        ddlGenerator
+            .Setup(d => d.GenerateDdl(It.IsAny<PgSchemaSnapshot>()))
+            .Returns([]);
+
+        bulkCopier
+            .Setup(b => b.CopyDataAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<IProgress<MigrationProgress>?>(), It.IsAny<int?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(500L);
+
+        bulkCopier
+            .Setup(b => b.ResetSequencesAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        validationEngine
+            .Setup(v => v.ValidateAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationSummary
+            {
+                AllPassed = false,
+                Results = [new ValidationResult { TableName = "public.orders", SourceRowCount = 500, TargetRowCount = 400, ChecksumMatch = false }],
+                TablesValidated = 1,
+                TablesPassed = 0,
+                TablesFailed = 1
+            });
+
+        var migrator = CreateMigrator(
+            schemaExtractor: schemaExtractor,
+            ddlGenerator: ddlGenerator,
+            bulkCopier: bulkCopier,
+            validationEngine: validationEngine,
+            extensionHandler: extensionHandler);
+
+        var plan = CreateValidPlan();
+
+        // Act
+        var result = await migrator.ExecuteCutoverAsync(plan);
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.Single(result.Validations);
+        Assert.False(result.Validations[0].Passed);
+    }
+
+    #endregion
+
+    #region ExecuteCutoverAsync — exception handling
+
+    [Fact]
+    public async Task ExecuteCutoverAsync_ExceptionDuringExecution_CapturedInResult()
+    {
+        // Arrange
+        var schemaExtractor = new Mock<PostgreSqlSchemaExtractor>();
+        schemaExtractor
+            .Setup(s => s.ExtractSchemaAsync(
+                It.IsAny<string>(), It.IsAny<IReadOnlyList<string>?>(),
+                It.IsAny<IProgress<MigrationProgress>?>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Connection refused"));
+
+        var migrator = CreateMigrator(schemaExtractor: schemaExtractor);
+        var plan = CreateValidPlan();
+
+        // Act
+        var result = await migrator.ExecuteCutoverAsync(plan);
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.Single(result.Errors);
+        Assert.Contains("Connection refused", result.Errors[0]);
+        Assert.NotNull(result.CompletedAt);
+    }
+
+    [Fact]
+    public async Task ExecuteCutoverAsync_OperationCancelled_IsNotCaught()
+    {
+        // Arrange
+        var schemaExtractor = new Mock<PostgreSqlSchemaExtractor>();
+        schemaExtractor
+            .Setup(s => s.ExtractSchemaAsync(
+                It.IsAny<string>(), It.IsAny<IReadOnlyList<string>?>(),
+                It.IsAny<IProgress<MigrationProgress>?>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
+
+        var migrator = CreateMigrator(schemaExtractor: schemaExtractor);
+        var plan = CreateValidPlan();
+
+        // Act & Assert — OperationCanceledException propagates
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => migrator.ExecuteCutoverAsync(plan));
+    }
+
+    #endregion
+
+    #region IMigrationEngine interface
+
+    [Fact]
+    public void ImplementsIMigrationEngine()
+    {
+        var migrator = CreateMigrator();
+        Assert.IsAssignableFrom<IMigrationEngine>(migrator);
+    }
+
+    #endregion
+}

--- a/tests/Scaffold.Migration.Tests/PostgreSql/PostgreSqlMigratorTests.cs
+++ b/tests/Scaffold.Migration.Tests/PostgreSql/PostgreSqlMigratorTests.cs
@@ -167,29 +167,40 @@ public class PostgreSqlMigratorTests
 
     #endregion
 
-    #region StartContinuousSyncAsync — not supported
+    #region StartContinuousSyncAsync — validates connection strings
 
     [Fact]
-    public async Task StartContinuousSyncAsync_ThrowsNotSupportedException()
+    public async Task StartContinuousSyncAsync_MissingSourceConnectionString_ThrowsArgumentException()
     {
         var migrator = CreateMigrator();
         var plan = CreateValidPlan();
+        plan.SourceConnectionString = null;
 
-        var ex = await Assert.ThrowsAsync<NotSupportedException>(
+        await Assert.ThrowsAsync<ArgumentException>(
             () => migrator.StartContinuousSyncAsync(plan));
-        Assert.Contains("logical replication", ex.Message);
+    }
+
+    [Fact]
+    public async Task StartContinuousSyncAsync_MissingTargetConnectionString_ThrowsArgumentException()
+    {
+        var migrator = CreateMigrator();
+        var plan = CreateValidPlan();
+        plan.ExistingTargetConnectionString = null;
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => migrator.StartContinuousSyncAsync(plan));
     }
 
     #endregion
 
-    #region CompleteCutoverAsync — not supported
+    #region CompleteCutoverAsync — requires active sync
 
     [Fact]
-    public async Task CompleteCutoverAsync_ThrowsNotSupportedException()
+    public async Task CompleteCutoverAsync_WithoutStartingSync_ThrowsInvalidOperationException()
     {
         var migrator = CreateMigrator();
 
-        var ex = await Assert.ThrowsAsync<NotSupportedException>(
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
             () => migrator.CompleteCutoverAsync(Guid.NewGuid()));
         Assert.Contains("StartContinuousSyncAsync", ex.Message);
     }

--- a/tests/Scaffold.Migration.Tests/PostgreSql/PostgreSqlSchemaExtractorTests.cs
+++ b/tests/Scaffold.Migration.Tests/PostgreSql/PostgreSqlSchemaExtractorTests.cs
@@ -106,10 +106,24 @@ public class PostgreSqlSchemaExtractorTests
     }
 
     [Fact]
-    public void BuildFullType_UserDefinedEnum_ReturnsUdtName()
+    public void BuildFullType_UserDefinedEnum_PublicSchema_ReturnsQuotedUdtName()
+    {
+        var result = PostgreSqlSchemaExtractor.BuildFullType("USER-DEFINED", "mood_type", null, null, null, "public");
+        Assert.Equal("\"mood_type\"", result);
+    }
+
+    [Fact]
+    public void BuildFullType_UserDefinedEnum_NullSchema_DefaultsToPublic()
     {
         var result = PostgreSqlSchemaExtractor.BuildFullType("USER-DEFINED", "mood_type", null, null, null);
-        Assert.Equal("mood_type", result);
+        Assert.Equal("\"mood_type\"", result);
+    }
+
+    [Fact]
+    public void BuildFullType_UserDefinedEnum_CustomSchema_SchemaQualified()
+    {
+        var result = PostgreSqlSchemaExtractor.BuildFullType("USER-DEFINED", "mood_type", null, null, null, "custom");
+        Assert.Equal("\"custom\".\"mood_type\"", result);
     }
 
     [Fact]
@@ -131,6 +145,22 @@ public class PostgreSqlSchemaExtractorTests
     {
         var result = PostgreSqlSchemaExtractor.BuildFullType("bit varying", null, 64, null, null);
         Assert.Equal("bit varying(64)", result);
+    }
+
+    #endregion
+
+    #region MapFkAction
+
+    [Theory]
+    [InlineData('a', "NO ACTION")]
+    [InlineData('r', "RESTRICT")]
+    [InlineData('c', "CASCADE")]
+    [InlineData('n', "SET NULL")]
+    [InlineData('d', "SET DEFAULT")]
+    [InlineData('x', "NO ACTION")] // unknown defaults to NO ACTION
+    public void MapFkAction_VariousChars_MapsCorrectly(char action, string expected)
+    {
+        Assert.Equal(expected, PostgreSqlSchemaExtractor.MapFkAction(action));
     }
 
     #endregion

--- a/tests/Scaffold.Migration.Tests/PostgreSql/PostgreSqlSchemaExtractorTests.cs
+++ b/tests/Scaffold.Migration.Tests/PostgreSql/PostgreSqlSchemaExtractorTests.cs
@@ -1,0 +1,302 @@
+using Scaffold.Migration.PostgreSql;
+using Scaffold.Migration.PostgreSql.Models;
+using Scaffold.Migration.Shared;
+
+namespace Scaffold.Migration.Tests.PostgreSql;
+
+public class PostgreSqlSchemaExtractorTests
+{
+    #region IsObjectIncluded
+
+    [Fact]
+    public void IsObjectIncluded_QualifiedMatch_ReturnsTrue()
+    {
+        var result = PostgreSqlSchemaExtractor.IsObjectIncluded(
+            "public", "users", ["public.users"]);
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsObjectIncluded_QualifiedMatch_CaseInsensitive()
+    {
+        var result = PostgreSqlSchemaExtractor.IsObjectIncluded(
+            "Public", "Users", ["public.users"]);
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsObjectIncluded_UnqualifiedMatch_ReturnsTrue()
+    {
+        var result = PostgreSqlSchemaExtractor.IsObjectIncluded(
+            "public", "users", ["users"]);
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsObjectIncluded_NoMatch_ReturnsFalse()
+    {
+        var result = PostgreSqlSchemaExtractor.IsObjectIncluded(
+            "public", "users", ["public.orders"]);
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsObjectIncluded_EmptyList_ReturnsFalse()
+    {
+        var result = PostgreSqlSchemaExtractor.IsObjectIncluded(
+            "public", "users", []);
+        Assert.False(result);
+    }
+
+    [Theory]
+    [InlineData("sales", "orders", "sales.orders", true)]
+    [InlineData("sales", "orders", "public.orders", false)]
+    [InlineData("sales", "orders", "orders", true)]
+    [InlineData("public", "items", "items", true)]
+    [InlineData("public", "items", "public.items", true)]
+    [InlineData("public", "items", "sales.items", false)]
+    public void IsObjectIncluded_VariousInputs(string schema, string table, string filter, bool expected)
+    {
+        var result = PostgreSqlSchemaExtractor.IsObjectIncluded(schema, table, [filter]);
+        Assert.Equal(expected, result);
+    }
+
+    #endregion
+
+    #region BuildFullType
+
+    [Theory]
+    [InlineData("integer", null, null, null, null, "integer")]
+    [InlineData("text", null, null, null, null, "text")]
+    [InlineData("boolean", null, null, null, null, "boolean")]
+    [InlineData("timestamp with time zone", null, null, null, null, "timestamp with time zone")]
+    public void BuildFullType_SimpleTypes_ReturnsTypeAsIs(
+        string dataType, string? udtName, int? maxLen, int? precision, int? scale, string expected)
+    {
+        var result = PostgreSqlSchemaExtractor.BuildFullType(dataType, udtName, maxLen, precision, scale);
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void BuildFullType_CharacterVaryingWithLength_IncludesLength()
+    {
+        var result = PostgreSqlSchemaExtractor.BuildFullType("character varying", null, 255, null, null);
+        Assert.Equal("character varying(255)", result);
+    }
+
+    [Fact]
+    public void BuildFullType_CharacterWithLength_IncludesLength()
+    {
+        var result = PostgreSqlSchemaExtractor.BuildFullType("character", null, 10, null, null);
+        Assert.Equal("character(10)", result);
+    }
+
+    [Fact]
+    public void BuildFullType_NumericWithPrecisionAndScale_IncludesBoth()
+    {
+        var result = PostgreSqlSchemaExtractor.BuildFullType("numeric", null, null, 18, 2);
+        Assert.Equal("numeric(18,2)", result);
+    }
+
+    [Fact]
+    public void BuildFullType_NumericWithPrecisionOnly_IncludesPrecision()
+    {
+        var result = PostgreSqlSchemaExtractor.BuildFullType("numeric", null, null, 10, 0);
+        Assert.Equal("numeric(10)", result);
+    }
+
+    [Fact]
+    public void BuildFullType_UserDefinedEnum_ReturnsUdtName()
+    {
+        var result = PostgreSqlSchemaExtractor.BuildFullType("USER-DEFINED", "mood_type", null, null, null);
+        Assert.Equal("mood_type", result);
+    }
+
+    [Fact]
+    public void BuildFullType_Array_ReturnsArrayNotation()
+    {
+        var result = PostgreSqlSchemaExtractor.BuildFullType("ARRAY", "_int4", null, null, null);
+        Assert.Equal("int4[]", result);
+    }
+
+    [Fact]
+    public void BuildFullType_BitWithLength_IncludesLength()
+    {
+        var result = PostgreSqlSchemaExtractor.BuildFullType("bit", null, 8, null, null);
+        Assert.Equal("bit(8)", result);
+    }
+
+    [Fact]
+    public void BuildFullType_BitVaryingWithLength_IncludesLength()
+    {
+        var result = PostgreSqlSchemaExtractor.BuildFullType("bit varying", null, 64, null, null);
+        Assert.Equal("bit varying(64)", result);
+    }
+
+    #endregion
+
+    #region ParseIndexDefinition
+
+    [Fact]
+    public void ParseIndexDefinition_SimpleIndex_ExtractsColumns()
+    {
+        var def = "CREATE INDEX idx_users_email ON public.users USING btree (email)";
+        var result = PostgreSqlSchemaExtractor.ParseIndexDefinition("idx_users_email", def);
+
+        Assert.Equal("idx_users_email", result.Name);
+        Assert.False(result.IsUnique);
+        Assert.Equal("btree", result.AccessMethod);
+        Assert.Single(result.Columns);
+        Assert.Equal("email", result.Columns[0]);
+        Assert.Null(result.FilterExpression);
+        Assert.Equal(def, result.RawDdl);
+    }
+
+    [Fact]
+    public void ParseIndexDefinition_UniqueIndex_SetsIsUnique()
+    {
+        var def = "CREATE UNIQUE INDEX idx_users_email ON public.users USING btree (email)";
+        var result = PostgreSqlSchemaExtractor.ParseIndexDefinition("idx_users_email", def);
+
+        Assert.True(result.IsUnique);
+    }
+
+    [Fact]
+    public void ParseIndexDefinition_GinIndex_ExtractsAccessMethod()
+    {
+        var def = "CREATE INDEX idx_docs_content ON public.documents USING gin (content)";
+        var result = PostgreSqlSchemaExtractor.ParseIndexDefinition("idx_docs_content", def);
+
+        Assert.Equal("gin", result.AccessMethod);
+    }
+
+    [Fact]
+    public void ParseIndexDefinition_MultiColumnIndex_ExtractsAllColumns()
+    {
+        var def = "CREATE INDEX idx_orders_user_date ON public.orders USING btree (user_id, created_at DESC)";
+        var result = PostgreSqlSchemaExtractor.ParseIndexDefinition("idx_orders_user_date", def);
+
+        Assert.Equal(2, result.Columns.Count);
+        Assert.Equal("user_id", result.Columns[0]);
+        Assert.Equal("created_at DESC", result.Columns[1]);
+    }
+
+    [Fact]
+    public void ParseIndexDefinition_PartialIndex_ExtractsFilter()
+    {
+        var def = "CREATE INDEX idx_active_users ON public.users USING btree (email) WHERE (is_active = true)";
+        var result = PostgreSqlSchemaExtractor.ParseIndexDefinition("idx_active_users", def);
+
+        Assert.Equal("(is_active = true)", result.FilterExpression);
+    }
+
+    [Fact]
+    public void ParseIndexDefinition_GistIndex_ExtractsAccessMethod()
+    {
+        var def = "CREATE INDEX idx_geo ON public.locations USING gist (coordinates)";
+        var result = PostgreSqlSchemaExtractor.ParseIndexDefinition("idx_geo", def);
+
+        Assert.Equal("gist", result.AccessMethod);
+    }
+
+    #endregion
+
+    #region TopologicalSort with PgTableDefinition
+
+    [Fact]
+    public void TopologicalSort_TablesWithFkDependencies_ParentsBeforeChildren()
+    {
+        var users = new PgTableDefinition { Schema = "public", TableName = "users" };
+        var orders = new PgTableDefinition
+        {
+            Schema = "public",
+            TableName = "orders",
+            ForeignKeys =
+            [
+                new PgForeignKeyDefinition
+                {
+                    Name = "fk_orders_users",
+                    ReferencedSchema = "public",
+                    ReferencedTable = "users",
+                    Columns = ["user_id"],
+                    ReferencedColumns = ["id"]
+                }
+            ]
+        };
+        var orderItems = new PgTableDefinition
+        {
+            Schema = "public",
+            TableName = "order_items",
+            ForeignKeys =
+            [
+                new PgForeignKeyDefinition
+                {
+                    Name = "fk_items_orders",
+                    ReferencedSchema = "public",
+                    ReferencedTable = "orders",
+                    Columns = ["order_id"],
+                    ReferencedColumns = ["id"]
+                }
+            ]
+        };
+
+        // Input in reverse order to ensure sorting works
+        var tables = new List<PgTableDefinition> { orderItems, orders, users };
+
+        var sorted = TopologicalSorter.Sort(
+            tables,
+            t => t.QualifiedName,
+            t => t.ForeignKeys.Select(fk => $"{fk.ReferencedSchema}.{fk.ReferencedTable}"));
+
+        Assert.Equal("public.users", sorted[0].QualifiedName);
+        Assert.Equal("public.orders", sorted[1].QualifiedName);
+        Assert.Equal("public.order_items", sorted[2].QualifiedName);
+    }
+
+    [Fact]
+    public void TopologicalSort_NoDependencies_PreservesOriginalOrder()
+    {
+        var a = new PgTableDefinition { Schema = "public", TableName = "alpha" };
+        var b = new PgTableDefinition { Schema = "public", TableName = "beta" };
+        var c = new PgTableDefinition { Schema = "public", TableName = "gamma" };
+
+        var tables = new List<PgTableDefinition> { a, b, c };
+
+        var sorted = TopologicalSorter.Sort(
+            tables,
+            t => t.QualifiedName,
+            t => t.ForeignKeys.Select(fk => $"{fk.ReferencedSchema}.{fk.ReferencedTable}"));
+
+        Assert.Equal("public.alpha", sorted[0].QualifiedName);
+        Assert.Equal("public.beta", sorted[1].QualifiedName);
+        Assert.Equal("public.gamma", sorted[2].QualifiedName);
+    }
+
+    #endregion
+
+    #region Column Type Edge Cases
+
+    [Fact]
+    public void BuildFullType_DecimalAlias_HandlesLikeNumeric()
+    {
+        var result = PostgreSqlSchemaExtractor.BuildFullType("decimal", null, null, 10, 4);
+        // "decimal" is treated same as "numeric" in BuildFullType
+        Assert.Equal("numeric(10,4)", result);
+    }
+
+    [Fact]
+    public void BuildFullType_CharacterVaryingNoLength_ReturnsTypeOnly()
+    {
+        var result = PostgreSqlSchemaExtractor.BuildFullType("character varying", null, null, null, null);
+        Assert.Equal("character varying", result);
+    }
+
+    [Fact]
+    public void BuildFullType_NumericNoPrecision_ReturnsTypeOnly()
+    {
+        var result = PostgreSqlSchemaExtractor.BuildFullType("numeric", null, null, null, null);
+        Assert.Equal("numeric", result);
+    }
+
+    #endregion
+}

--- a/tests/Scaffold.Migration.Tests/PostgreSql/PostgreSqlToPostgreSqlValidationEngineTests.cs
+++ b/tests/Scaffold.Migration.Tests/PostgreSql/PostgreSqlToPostgreSqlValidationEngineTests.cs
@@ -1,0 +1,46 @@
+using Scaffold.Migration.PostgreSql;
+
+namespace Scaffold.Migration.Tests.PostgreSql;
+
+public class PostgreSqlToPostgreSqlValidationEngineTests
+{
+    [Fact]
+    public async Task ValidateAsync_EmptyTableList_ReturnsPassingSummary()
+    {
+        // Arrange
+        var engine = new PostgreSqlToPostgreSqlValidationEngine();
+        var emptyTables = new List<string>();
+
+        // Act
+        var summary = await engine.ValidateAsync(
+            "Host=source;Database=db;",
+            "Host=target;Database=db;",
+            emptyTables);
+
+        // Assert
+        Assert.NotNull(summary);
+        Assert.Empty(summary.Results);
+        Assert.Equal(0, summary.TablesValidated);
+        Assert.Equal(0, summary.TablesPassed);
+        Assert.Equal(0, summary.TablesFailed);
+        Assert.True(summary.AllPassed);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_CancellationRequested_ThrowsOperationCanceledException()
+    {
+        // Arrange
+        var engine = new PostgreSqlToPostgreSqlValidationEngine();
+        var tables = new List<string> { "public.users" };
+        using var cts = new CancellationTokenSource();
+        cts.Cancel(); // Cancel immediately
+
+        // Act & Assert
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => engine.ValidateAsync(
+                "Host=source;Database=db;",
+                "Host=target;Database=db;",
+                tables,
+                cts.Token));
+    }
+}

--- a/tests/Scaffold.Migration.Tests/PostgreSql/ReplicationRetryPolicyTests.cs
+++ b/tests/Scaffold.Migration.Tests/PostgreSql/ReplicationRetryPolicyTests.cs
@@ -1,0 +1,491 @@
+using Npgsql;
+using Scaffold.Migration.PostgreSql;
+
+namespace Scaffold.Migration.Tests.PostgreSql;
+
+public class ReplicationRetryPolicyTests
+{
+    #region Constructor and defaults
+
+    [Fact]
+    public void Constructor_DefaultValues_AreReasonable()
+    {
+        var policy = new ReplicationRetryPolicy();
+
+        Assert.Equal(5, policy.MaxRetries);
+        Assert.Equal(TimeSpan.FromSeconds(1), policy.InitialDelay);
+        Assert.Equal(TimeSpan.FromSeconds(60), policy.MaxDelay);
+        Assert.Equal(10, policy.CircuitBreakerThreshold);
+        Assert.Equal(0, policy.ConsecutiveFailures);
+        Assert.False(policy.IsCircuitOpen);
+    }
+
+    [Fact]
+    public void Constructor_CustomValues_ArePreserved()
+    {
+        var policy = new ReplicationRetryPolicy(
+            maxRetries: 3,
+            initialDelay: TimeSpan.FromMilliseconds(500),
+            maxDelay: TimeSpan.FromSeconds(30),
+            circuitBreakerThreshold: 5);
+
+        Assert.Equal(3, policy.MaxRetries);
+        Assert.Equal(TimeSpan.FromMilliseconds(500), policy.InitialDelay);
+        Assert.Equal(TimeSpan.FromSeconds(30), policy.MaxDelay);
+        Assert.Equal(5, policy.CircuitBreakerThreshold);
+    }
+
+    #endregion
+
+    #region CalculateDelay
+
+    [Fact]
+    public void CalculateDelay_Attempt0_IsAroundInitialDelay()
+    {
+        var policy = new ReplicationRetryPolicy(initialDelay: TimeSpan.FromSeconds(1));
+
+        var delay = policy.CalculateDelay(0);
+
+        // Base = 1s * 2^0 = 1s, plus up to 30% jitter = 1.0–1.3s
+        Assert.InRange(delay.TotalMilliseconds, 1000, 1300);
+    }
+
+    [Fact]
+    public void CalculateDelay_Attempt1_IsAroundDouble()
+    {
+        var policy = new ReplicationRetryPolicy(initialDelay: TimeSpan.FromSeconds(1));
+
+        var delay = policy.CalculateDelay(1);
+
+        // Base = 1s * 2^1 = 2s, plus up to 30% jitter = 2.0–2.6s
+        Assert.InRange(delay.TotalMilliseconds, 2000, 2600);
+    }
+
+    [Fact]
+    public void CalculateDelay_Attempt4_IsAroundSixteenSeconds()
+    {
+        var policy = new ReplicationRetryPolicy(initialDelay: TimeSpan.FromSeconds(1));
+
+        var delay = policy.CalculateDelay(4);
+
+        // Base = 1s * 2^4 = 16s, plus up to 30% jitter = 16–20.8s
+        Assert.InRange(delay.TotalMilliseconds, 16000, 20800);
+    }
+
+    [Fact]
+    public void CalculateDelay_ExceedingMaxDelay_IsCapped()
+    {
+        var policy = new ReplicationRetryPolicy(
+            initialDelay: TimeSpan.FromSeconds(10),
+            maxDelay: TimeSpan.FromSeconds(30));
+
+        var delay = policy.CalculateDelay(5);
+
+        // Base = 10s * 2^5 = 320s, but capped at 30s
+        Assert.True(delay.TotalSeconds <= 30,
+            $"Delay {delay.TotalSeconds:F1}s exceeds maxDelay of 30s");
+    }
+
+    [Fact]
+    public void CalculateDelay_MultipleAttempts_Grows()
+    {
+        var policy = new ReplicationRetryPolicy(
+            initialDelay: TimeSpan.FromSeconds(1),
+            maxDelay: TimeSpan.FromSeconds(120));
+
+        // Run many samples to verify trend (exponential growth)
+        var delay0 = Enumerable.Range(0, 100)
+            .Select(_ => policy.CalculateDelay(0).TotalMilliseconds).Average();
+        var delay2 = Enumerable.Range(0, 100)
+            .Select(_ => policy.CalculateDelay(2).TotalMilliseconds).Average();
+
+        Assert.True(delay2 > delay0, "Delay should grow with attempt number");
+    }
+
+    #endregion
+
+    #region IsTransient
+
+    [Theory]
+    [InlineData("08000")] // connection_exception
+    [InlineData("08001")] // sqlclient_unable_to_establish_sqlconnection
+    [InlineData("08003")] // connection_does_not_exist
+    [InlineData("08006")] // connection_failure
+    [InlineData("40001")] // serialization_failure
+    [InlineData("40P01")] // deadlock_detected
+    [InlineData("53000")] // insufficient_resources
+    [InlineData("53100")] // disk_full
+    [InlineData("53200")] // out_of_memory
+    [InlineData("53300")] // too_many_connections
+    [InlineData("57P01")] // admin_shutdown
+    [InlineData("57P02")] // crash_shutdown
+    [InlineData("57P03")] // cannot_connect_now
+    public void IsTransient_TransientSqlStates_ReturnsTrue(string sqlState)
+    {
+        var ex = CreatePostgresException(sqlState);
+
+        Assert.True(ReplicationRetryPolicy.IsTransient(ex));
+    }
+
+    [Theory]
+    [InlineData("23505")] // unique_violation
+    [InlineData("42P01")] // undefined_table
+    [InlineData("42601")] // syntax_error
+    [InlineData("42501")] // insufficient_privilege
+    [InlineData("23503")] // foreign_key_violation
+    public void IsTransient_NonTransientSqlStates_ReturnsFalse(string sqlState)
+    {
+        var ex = CreatePostgresException(sqlState);
+
+        Assert.False(ReplicationRetryPolicy.IsTransient(ex));
+    }
+
+    [Fact]
+    public void IsTransient_IOException_ReturnsTrue()
+    {
+        var ex = new NpgsqlException("Connection lost", new System.IO.IOException("pipe broken"));
+
+        Assert.True(ReplicationRetryPolicy.IsTransient(ex));
+    }
+
+    [Fact]
+    public void IsTransient_SocketException_ReturnsTrue()
+    {
+        var ex = new NpgsqlException("Connection lost",
+            new System.Net.Sockets.SocketException(10054));
+
+        Assert.True(ReplicationRetryPolicy.IsTransient(ex));
+    }
+
+    [Fact]
+    public void IsTransient_NpgsqlExceptionWithNoInnerOrSqlState_ReturnsFalse()
+    {
+        var ex = new NpgsqlException("Generic error");
+
+        Assert.False(ReplicationRetryPolicy.IsTransient(ex));
+    }
+
+    #endregion
+
+    #region ExecuteAsync<T>
+
+    [Fact]
+    public async Task ExecuteAsync_SucceedsFirstTry_ReturnsResult()
+    {
+        var policy = new ReplicationRetryPolicy();
+        int callCount = 0;
+
+        var result = await policy.ExecuteAsync(ct =>
+        {
+            callCount++;
+            return Task.FromResult(42);
+        });
+
+        Assert.Equal(42, result);
+        Assert.Equal(1, callCount);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SucceedsFirstTry_ResetsFailures()
+    {
+        var policy = new ReplicationRetryPolicy();
+        // Pre-record some failures
+        policy.RecordFailure();
+        policy.RecordFailure();
+        Assert.Equal(2, policy.ConsecutiveFailures);
+
+        await policy.ExecuteAsync(ct => Task.FromResult(true));
+
+        Assert.Equal(0, policy.ConsecutiveFailures);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_TransientFailureThenSuccess_ReturnsResult()
+    {
+        var policy = new ReplicationRetryPolicy(
+            maxRetries: 3,
+            initialDelay: TimeSpan.FromMilliseconds(1),
+            maxDelay: TimeSpan.FromMilliseconds(10));
+
+        int callCount = 0;
+
+        var result = await policy.ExecuteAsync(ct =>
+        {
+            callCount++;
+            if (callCount < 3)
+            {
+                throw new NpgsqlException("transient",
+                    new System.IO.IOException("connection reset"));
+            }
+            return Task.FromResult("success");
+        });
+
+        Assert.Equal("success", result);
+        Assert.Equal(3, callCount);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ExhaustsRetries_Throws()
+    {
+        var policy = new ReplicationRetryPolicy(
+            maxRetries: 2,
+            initialDelay: TimeSpan.FromMilliseconds(1),
+            maxDelay: TimeSpan.FromMilliseconds(10));
+
+        int callCount = 0;
+
+        await Assert.ThrowsAsync<NpgsqlException>(() =>
+            policy.ExecuteAsync<int>(ct =>
+            {
+                callCount++;
+                throw new NpgsqlException("transient",
+                    new System.IO.IOException("always fails"));
+            }));
+
+        // maxRetries=2 means 3 attempts (0, 1, 2)
+        Assert.Equal(3, callCount);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NonTransientException_DoesNotRetry()
+    {
+        var policy = new ReplicationRetryPolicy(
+            maxRetries: 5,
+            initialDelay: TimeSpan.FromMilliseconds(1));
+
+        int callCount = 0;
+
+        await Assert.ThrowsAsync<NpgsqlException>(() =>
+            policy.ExecuteAsync<int>(ct =>
+            {
+                callCount++;
+                throw new NpgsqlException("non-transient error");
+            }));
+
+        // Non-transient: not caught by the 'when' clause, so it propagates immediately
+        Assert.Equal(1, callCount);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NullOperation_ThrowsArgumentNullException()
+    {
+        var policy = new ReplicationRetryPolicy();
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            policy.ExecuteAsync<int>(null!));
+    }
+
+    #endregion
+
+    #region ExecuteAsync (void overload)
+
+    [Fact]
+    public async Task ExecuteAsyncVoid_SucceedsFirstTry_Completes()
+    {
+        var policy = new ReplicationRetryPolicy();
+        int callCount = 0;
+
+        await policy.ExecuteAsync(ct =>
+        {
+            callCount++;
+            return Task.CompletedTask;
+        });
+
+        Assert.Equal(1, callCount);
+    }
+
+    [Fact]
+    public async Task ExecuteAsyncVoid_TransientFailureThenSuccess_Completes()
+    {
+        var policy = new ReplicationRetryPolicy(
+            maxRetries: 3,
+            initialDelay: TimeSpan.FromMilliseconds(1),
+            maxDelay: TimeSpan.FromMilliseconds(10));
+
+        int callCount = 0;
+
+        await policy.ExecuteAsync(ct =>
+        {
+            callCount++;
+            if (callCount < 2)
+            {
+                throw new NpgsqlException("transient",
+                    new System.IO.IOException("connection reset"));
+            }
+            return Task.CompletedTask;
+        });
+
+        Assert.Equal(2, callCount);
+    }
+
+    [Fact]
+    public async Task ExecuteAsyncVoid_NullOperation_ThrowsArgumentNullException()
+    {
+        var policy = new ReplicationRetryPolicy();
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            policy.ExecuteAsync((Func<CancellationToken, Task>)null!));
+    }
+
+    #endregion
+
+    #region RecordSuccess / RecordFailure
+
+    [Fact]
+    public void RecordSuccess_ResetsConsecutiveFailures()
+    {
+        var policy = new ReplicationRetryPolicy();
+        policy.RecordFailure();
+        policy.RecordFailure();
+        policy.RecordFailure();
+        Assert.Equal(3, policy.ConsecutiveFailures);
+
+        policy.RecordSuccess();
+
+        Assert.Equal(0, policy.ConsecutiveFailures);
+    }
+
+    [Fact]
+    public void RecordFailure_IncrementsConsecutiveFailures()
+    {
+        var policy = new ReplicationRetryPolicy();
+
+        policy.RecordFailure();
+        Assert.Equal(1, policy.ConsecutiveFailures);
+
+        policy.RecordFailure();
+        Assert.Equal(2, policy.ConsecutiveFailures);
+
+        policy.RecordFailure();
+        Assert.Equal(3, policy.ConsecutiveFailures);
+    }
+
+    #endregion
+
+    #region Circuit breaker
+
+    [Fact]
+    public void CircuitBreaker_OpensAfterThresholdFailures()
+    {
+        var policy = new ReplicationRetryPolicy(circuitBreakerThreshold: 3);
+
+        policy.RecordFailure(); // 1
+        policy.RecordFailure(); // 2
+        Assert.False(policy.IsCircuitOpen);
+
+        policy.RecordFailure(); // 3 — reaches threshold
+        Assert.True(policy.IsCircuitOpen);
+    }
+
+    [Fact]
+    public async Task CircuitBreaker_PreventsExecution_WhenOpen()
+    {
+        var policy = new ReplicationRetryPolicy(circuitBreakerThreshold: 1);
+        policy.RecordFailure(); // Opens circuit
+
+        var ex = await Assert.ThrowsAsync<CircuitBreakerOpenException>(() =>
+            policy.ExecuteAsync(ct => Task.FromResult(42)));
+        Assert.Contains("Circuit breaker is open", ex.Message);
+    }
+
+    [Fact]
+    public void CircuitBreaker_ResetsAfterSuccess()
+    {
+        var policy = new ReplicationRetryPolicy(circuitBreakerThreshold: 2);
+
+        policy.RecordFailure();
+        policy.RecordFailure();
+        Assert.True(policy.IsCircuitOpen);
+
+        policy.RecordSuccess();
+
+        Assert.False(policy.IsCircuitOpen);
+        Assert.Equal(0, policy.ConsecutiveFailures);
+    }
+
+    #endregion
+
+    #region CircuitBreakerOpenException
+
+    [Fact]
+    public void CircuitBreakerOpenException_ContainsUsefulMessage()
+    {
+        var ex = new CircuitBreakerOpenException("test message");
+
+        Assert.Equal("test message", ex.Message);
+    }
+
+    [Fact]
+    public void CircuitBreakerOpenException_DefaultConstructor_Works()
+    {
+        var ex = new CircuitBreakerOpenException();
+
+        Assert.NotNull(ex);
+    }
+
+    [Fact]
+    public void CircuitBreakerOpenException_WithInnerException_Works()
+    {
+        var inner = new InvalidOperationException("inner");
+        var ex = new CircuitBreakerOpenException("outer", inner);
+
+        Assert.Equal("outer", ex.Message);
+        Assert.Same(inner, ex.InnerException);
+    }
+
+    #endregion
+
+    #region Cancellation
+
+    [Fact]
+    public async Task ExecuteAsync_CancelledToken_ThrowsOperationCanceledException()
+    {
+        var policy = new ReplicationRetryPolicy();
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            policy.ExecuteAsync(ct => Task.FromResult(42), cts.Token));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CancelledDuringRetryDelay_ThrowsOperationCanceledException()
+    {
+        var policy = new ReplicationRetryPolicy(
+            maxRetries: 5,
+            initialDelay: TimeSpan.FromSeconds(30)); // long delay
+
+        using var cts = new CancellationTokenSource();
+        int callCount = 0;
+
+        var task = policy.ExecuteAsync<int>(ct =>
+        {
+            callCount++;
+            throw new NpgsqlException("transient",
+                new System.IO.IOException("connection reset"));
+        }, cts.Token);
+
+        // Cancel shortly after the first failure triggers a retry delay
+        await Task.Delay(50);
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static PostgresException CreatePostgresException(string sqlState)
+    {
+        // PostgresException requires specific construction; use reflection or helper
+        // The simplest way is to use the PostgresException constructor that's available
+        return new PostgresException(
+            messageText: $"Error with state {sqlState}",
+            severity: "ERROR",
+            invariantSeverity: "ERROR",
+            sqlState: sqlState);
+    }
+
+    #endregion
+}

--- a/tests/Scaffold.Migration.Tests/Shared/TopologicalSorterTests.cs
+++ b/tests/Scaffold.Migration.Tests/Shared/TopologicalSorterTests.cs
@@ -1,0 +1,199 @@
+using Scaffold.Migration.Shared;
+
+namespace Scaffold.Migration.Tests.Shared;
+
+public class TopologicalSorterTests
+{
+    #region String Sort
+
+    [Fact]
+    public void Sort_NoDependencies_PreservesOriginalOrder()
+    {
+        var items = new List<string> { "A", "B", "C" };
+        var deps = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["A"] = [],
+            ["B"] = [],
+            ["C"] = []
+        };
+
+        var result = TopologicalSorter.Sort(items, deps);
+
+        Assert.Equal(["A", "B", "C"], result);
+    }
+
+    [Fact]
+    public void Sort_SimpleChain_ParentsBeforeChildren()
+    {
+        // C depends on B, B depends on A → order should be A, B, C
+        var items = new List<string> { "C", "B", "A" };
+        var deps = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["A"] = [],
+            ["B"] = new(["A"], StringComparer.OrdinalIgnoreCase),
+            ["C"] = new(["B"], StringComparer.OrdinalIgnoreCase)
+        };
+
+        var result = TopologicalSorter.Sort(items, deps);
+
+        var indexA = result.IndexOf("A");
+        var indexB = result.IndexOf("B");
+        var indexC = result.IndexOf("C");
+
+        Assert.True(indexA < indexB, "A should come before B");
+        Assert.True(indexB < indexC, "B should come before C");
+        Assert.Equal(3, result.Count);
+    }
+
+    [Fact]
+    public void Sort_DiamondDependency_HandlesCorrectly()
+    {
+        // D depends on B and C; B depends on A; C depends on A
+        var items = new List<string> { "D", "C", "B", "A" };
+        var deps = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["A"] = [],
+            ["B"] = new(["A"], StringComparer.OrdinalIgnoreCase),
+            ["C"] = new(["A"], StringComparer.OrdinalIgnoreCase),
+            ["D"] = new(["B", "C"], StringComparer.OrdinalIgnoreCase)
+        };
+
+        var result = TopologicalSorter.Sort(items, deps);
+
+        var indexA = result.IndexOf("A");
+        var indexB = result.IndexOf("B");
+        var indexC = result.IndexOf("C");
+        var indexD = result.IndexOf("D");
+
+        Assert.True(indexA < indexB, "A should come before B");
+        Assert.True(indexA < indexC, "A should come before C");
+        Assert.True(indexB < indexD, "B should come before D");
+        Assert.True(indexC < indexD, "C should come before D");
+    }
+
+    [Fact]
+    public void Sort_CircularDependency_AppendsRemainingInOriginalOrder()
+    {
+        // A depends on B, B depends on A → circular
+        var items = new List<string> { "A", "B", "C" };
+        var deps = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["A"] = new(["B"], StringComparer.OrdinalIgnoreCase),
+            ["B"] = new(["A"], StringComparer.OrdinalIgnoreCase),
+            ["C"] = []
+        };
+
+        var result = TopologicalSorter.Sort(items, deps);
+
+        // C has no deps, should come first
+        Assert.Equal("C", result[0]);
+        // A and B are circular, appended in original order (A before B)
+        Assert.Equal(3, result.Count);
+        Assert.Contains("A", result);
+        Assert.Contains("B", result);
+    }
+
+    [Fact]
+    public void Sort_CaseInsensitive_MatchesDependencies()
+    {
+        var items = new List<string> { "child", "Parent" };
+        var deps = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Parent"] = [],
+            ["child"] = new(["parent"], StringComparer.OrdinalIgnoreCase)
+        };
+
+        var result = TopologicalSorter.Sort(items, deps);
+
+        var indexParent = result.IndexOf("Parent");
+        var indexChild = result.IndexOf("child");
+
+        Assert.True(indexParent < indexChild, "Parent should come before child");
+    }
+
+    #endregion
+
+    #region Generic Sort<T>
+
+    private record TableDef(string Schema, string Name, List<string> FkRefs);
+
+    [Fact]
+    public void SortGeneric_SimpleChain_OrdersByDependency()
+    {
+        var tables = new List<TableDef>
+        {
+            new("dbo", "Orders", ["dbo.Users"]),
+            new("dbo", "Users", [])
+        };
+
+        var result = TopologicalSorter.Sort(
+            tables,
+            t => $"{t.Schema}.{t.Name}",
+            t => t.FkRefs);
+
+        Assert.Equal("Users", result[0].Name);
+        Assert.Equal("Orders", result[1].Name);
+    }
+
+    [Fact]
+    public void SortGeneric_SelfReference_ExcludedFromDependencies()
+    {
+        var tables = new List<TableDef>
+        {
+            new("dbo", "Employees", ["dbo.Employees"]), // self-referencing FK
+            new("dbo", "Departments", [])
+        };
+
+        var result = TopologicalSorter.Sort(
+            tables,
+            t => $"{t.Schema}.{t.Name}",
+            t => t.FkRefs);
+
+        // Both should be in the result
+        Assert.Equal(2, result.Count);
+        // Self-reference shouldn't block ordering
+        Assert.Contains(result, t => t.Name == "Employees");
+        Assert.Contains(result, t => t.Name == "Departments");
+    }
+
+    [Fact]
+    public void SortGeneric_ExternalDependency_Ignored()
+    {
+        // Orders references Users, but Users is not in the items list
+        var tables = new List<TableDef>
+        {
+            new("dbo", "Orders", ["dbo.Users"]),
+            new("dbo", "Products", [])
+        };
+
+        var result = TopologicalSorter.Sort(
+            tables,
+            t => $"{t.Schema}.{t.Name}",
+            t => t.FkRefs);
+
+        // External dep (Users) not in set → Orders has no effective deps
+        Assert.Equal(2, result.Count);
+    }
+
+    [Fact]
+    public void SortGeneric_NoDependencies_PreservesOriginalOrder()
+    {
+        var tables = new List<TableDef>
+        {
+            new("dbo", "Alpha", []),
+            new("dbo", "Beta", []),
+            new("dbo", "Gamma", [])
+        };
+
+        var result = TopologicalSorter.Sort(
+            tables,
+            t => $"{t.Schema}.{t.Name}",
+            t => t.FkRefs);
+
+        Assert.Equal("Alpha", result[0].Name);
+        Assert.Equal("Beta", result[1].Name);
+        Assert.Equal("Gamma", result[2].Name);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Phase 3: PostgreSQL → Azure PostgreSQL Migration

Implements same-platform PG→PG migration engine with cutover and continuous sync (logical replication) strategies.

### Issues

- [ ] #32 — PostgreSQL schema extractor
- [ ] #33 — PostgreSQL-to-PostgreSQL data copier
- [ ] #34 — PostgreSQL logical replication sync engine
- [ ] #35 — Create PostgreSqlMigrator orchestrator
- [ ] #36 — Azure PG extension compatibility handler
- [ ] #37 — PG → Azure PG integration tests
- [ ] #82 — Migration cancellation/abort endpoint
- [ ] #83 — Logical replication failure and retry strategy

### Milestone
Phase 3: PostgreSQL Migration (PG → Azure PG)

### Implementation Order
Dependency-ordered waves — see architect review for details.

Closes #32, closes #33, closes #34, closes #35, closes #36, closes #37, closes #82, closes #83
